### PR TITLE
refactor: replace SkippedFile errors with specifics

### DIFF
--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -33,8 +33,9 @@ from .chunking import (
 )
 from .detection import LANGUAGES, detect_language, get_language_name
 from .utils import (
+    AlreadyInTargetLanguageError,
     ConfigParsingError,
-    SkippedFileError,
+    EmptyFileError,
     TranslationError,
     read_file_with_fallback,
 )
@@ -171,18 +172,15 @@ class _TranslateBase:
 
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
-        try:
-            _translate_file(
-                context.translator,
-                input_file,
-                output_file,
-                context.source_lang,
-                context.target_lang,
-                logger.info,
-            )
-        except SkippedFileError as e:
-            logger.warning(f"  Skipping: {e}")
-            return
+
+        _translate_file(
+            context.translator,
+            input_file,
+            output_file,
+            context.source_lang,
+            context.target_lang,
+            logger.info,
+        )
 
         logger.info("Translation complete!")
 
@@ -269,7 +267,8 @@ def _translate_file(
         on_progress: Callback for progress messages.
 
     Raises:
-        SkippedFileError: If file should be skipped.
+        EmptyFileError: If the input file is empty.
+        AlreadyInTargetLanguageError: If the input file is already 'translated.'
         TranslationError: If translation fails.
     """
     on_progress(f"Processing: {input_file.name}")
@@ -277,7 +276,7 @@ def _translate_file(
     content = read_file_with_fallback(input_file)
 
     if not content.strip():
-        raise SkippedFileError("Empty file")
+        raise EmptyFileError("Empty file")
 
     on_progress(f"  File size: {len(content):,} characters")
 
@@ -298,7 +297,9 @@ def _translate_file(
         )
 
     if detected_lang == target_lang:
-        raise SkippedFileError(f"Already in {get_language_name(target_lang)}")
+        raise AlreadyInTargetLanguageError(
+            f"Already in {get_language_name(target_lang)}"
+        )
 
     if detected_lang not in LANGUAGES:
         on_progress(

--- a/src/tigerflow_ml/text/translate/utils.py
+++ b/src/tigerflow_ml/text/translate/utils.py
@@ -13,9 +13,15 @@ class TranslationError(Exception):
     pass
 
 
-class SkippedFileError(Exception):
-    """Raised when a file should be skipped
-    (e.g., empty, already in target language)."""
+class EmptyFileError(Exception):
+    """Raised when a input file is empty"""
+
+    pass
+
+
+class AlreadyInTargetLanguageError(Exception):
+    """Raised when input text is already in the
+    target language"""
 
     pass
 

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -10,6 +10,7 @@ from tigerflow_ml.text.translate._base import (
     _translate_chunk_with_retry,
     _translate_file,
     _translate_text,
+    _TranslateBase,
 )
 from tigerflow_ml.text.translate.translator import (
     GemmaTranslator,
@@ -193,6 +194,26 @@ class TestTranslateFile:
         ):
             with pytest.raises(TranslationError):
                 _translate_file(MagicMock(), input_file, tmp_path / "out.txt")
+
+
+class TestRun:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            EmptyFileError("empty"),
+            AlreadyInTargetLanguageError("same lang"),
+            TranslationError("failed"),
+        ],
+    )
+    def test_run_propagates_translate_file_errors(self, tmp_path, error):
+        context = SimpleNamespace(
+            translator=MagicMock(), source_lang=None, target_lang="en"
+        )
+        with patch(
+            "tigerflow_ml.text.translate._base._translate_file", side_effect=error
+        ):
+            with pytest.raises(type(error)):
+                _TranslateBase.run(context, tmp_path / "in.txt", tmp_path / "out.txt")
 
 
 def _make_tgemma_hf_translator(mock_tokenizer, max_chunk_tokens=5, batch_size=4):

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -8,6 +8,7 @@ import pytest
 from tigerflow_ml.text.translate._base import (
     _DEFAULT_PROMPT,
     _translate_chunk_with_retry,
+    _translate_file,
     _translate_text,
 )
 from tigerflow_ml.text.translate.translator import (
@@ -16,7 +17,11 @@ from tigerflow_ml.text.translate.translator import (
     get_model_type,
     vllmTranslator,
 )
-from tigerflow_ml.text.translate.utils import TranslationError
+from tigerflow_ml.text.translate.utils import (
+    AlreadyInTargetLanguageError,
+    EmptyFileError,
+    TranslationError,
+)
 
 
 @pytest.fixture
@@ -160,6 +165,34 @@ class TestTranslateText:
             _translate_text(text, mock_translator, "de", "en")
 
         mock_translator.translate.assert_not_called()
+
+
+class TestTranslateFile:
+    def test_empty_file_raises(self, tmp_path):
+        empty_file = tmp_path / "empty.txt"
+        empty_file.write_text("")
+        with pytest.raises(EmptyFileError):
+            _translate_file(MagicMock(), empty_file, tmp_path / "out.txt")
+
+    def test_already_in_target_lang_raises(self, tmp_path):
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Hello world")
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value="en"
+        ):
+            with pytest.raises(AlreadyInTargetLanguageError):
+                _translate_file(
+                    MagicMock(), input_file, tmp_path / "out.txt", target_lang="en"
+                )
+
+    def test_language_detection_fails_raises(self, tmp_path):
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Hello world")
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            with pytest.raises(TranslationError):
+                _translate_file(MagicMock(), input_file, tmp_path / "out.txt")
 
 
 def _make_tgemma_hf_translator(mock_tokenizer, max_chunk_tokens=5, batch_size=4):

--- a/tests/unit/text/translate/test_utils.py
+++ b/tests/unit/text/translate/test_utils.py
@@ -4,7 +4,8 @@ import pytest
 
 from tigerflow_ml.text.translate.utils import (
     ENCODING_FALLBACK_CHAIN,
-    SkippedFileError,
+    AlreadyInTargetLanguageError,
+    EmptyFileError,
     TranslationError,
     read_file_with_fallback,
 )
@@ -15,9 +16,13 @@ class TestExceptions:
         with pytest.raises(TranslationError):
             raise TranslationError("test error")
 
-    def test_skipped_file_error_is_exception(self):
-        with pytest.raises(SkippedFileError):
-            raise SkippedFileError("test skip")
+    def test_empty_file_error_is_exception(self):
+        with pytest.raises(EmptyFileError):
+            raise EmptyFileError("test file empty")
+
+    def test_already_in_taget_lang_error_is_exception(self):
+        with pytest.raises(AlreadyInTargetLanguageError):
+            raise AlreadyInTargetLanguageError("test already translated")
 
     def test_exception_messages(self):
         try:

--- a/tests/unit/text/translate/test_utils.py
+++ b/tests/unit/text/translate/test_utils.py
@@ -4,31 +4,8 @@ import pytest
 
 from tigerflow_ml.text.translate.utils import (
     ENCODING_FALLBACK_CHAIN,
-    AlreadyInTargetLanguageError,
-    EmptyFileError,
-    TranslationError,
     read_file_with_fallback,
 )
-
-
-class TestExceptions:
-    def test_translation_error_is_exception(self):
-        with pytest.raises(TranslationError):
-            raise TranslationError("test error")
-
-    def test_empty_file_error_is_exception(self):
-        with pytest.raises(EmptyFileError):
-            raise EmptyFileError("test file empty")
-
-    def test_already_in_taget_lang_error_is_exception(self):
-        with pytest.raises(AlreadyInTargetLanguageError):
-            raise AlreadyInTargetLanguageError("test already translated")
-
-    def test_exception_messages(self):
-        try:
-            raise TranslationError("custom message")
-        except TranslationError as e:
-            assert str(e) == "custom message"
 
 
 class TestEncodingFallbackChain:


### PR DESCRIPTION
closes #52 


Replaces `SkippedFileError` with the more specific `EmptyFileError` and `AlreadyInTargetLanguageError`