### PR TITLE
53 fallback prompt

### DIFF
--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -117,8 +117,7 @@ class _TranslateBase:
             bool,
             typer.Option(
                 help="Use a fallback prompt for files where language detection fails. "
-                '("Translate the following text to {target_lang}. '
-                'Output only the translated text, nothing else. Text: {text}")'
+                f'("{_FALLBACK_PROMPT}")'
             ),
         ] = False
 

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -125,8 +125,13 @@ class _TranslateBase:
     @staticmethod
     def setup(context: SetupContext):
         from transformers import AutoConfig
-
         from .translator import build_translator
+        
+        if "{text}" not in context.prompt_template:
+            raise ValueError(
+                '--prompt-template needs to contain "{text}".'
+                " This is a placeholder for input file contents."
+            )
 
         try:
             config = AutoConfig.from_pretrained(

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -113,6 +113,15 @@ class _TranslateBase:
             typer.Option(hidden=True),
         ] = int(DEFAULT_CHUNK_SIZE * 2.5)  # unused
 
+        use_fallback_prompt: Annotated[
+            bool,
+            typer.Option(
+                help="Use a fallback prompt for files where language detection fails. "
+                '("Translate the following text to {target_lang}. '
+                'Output only the translated text, nothing else. Text: {text}")'
+            ),
+        ] = False
+
     @staticmethod
     def setup(context: SetupContext):
         from transformers import AutoConfig
@@ -179,6 +188,7 @@ class _TranslateBase:
             context.source_lang,
             context.target_lang,
             logger.info,
+            use_fallback_prompt=context.use_fallback_prompt,
         )
 
         logger.info("Translation complete!")
@@ -252,6 +262,7 @@ def _translate_file(
     source_lang: str | None = None,
     target_lang: str = "en",
     on_progress: Callable[..., None] = print,
+    use_fallback_prompt: bool = False,
 ) -> str:
     """
     Translate a single file.
@@ -284,15 +295,17 @@ def _translate_file(
     if detected_lang is None:
         detected_lang = detect_language(content)
         if detected_lang is None:
-            if translator.prompt_template == _DEFAULT_PROMPT:
+            if use_fallback_prompt:
                 logger.warning(
-                    "Could not detect language (text may be too short or mixed)."
+                    "  Could not detect language (text may be too short or mixed)."
                     f" Attempting to use fallback prompt: {_FALLBACK_PROMPT}"
                 )
                 translator.prompt_template = _FALLBACK_PROMPT
             else:
                 raise TranslationError(
-                    "Could not detect language (text may be too short or mixed)"
+                    "Could not detect language (text may be too short or mixed). "
+                    "Explicitly set --source-lang to skip language detection or run "
+                    "with --use-fallback-prompt"
                 )
         else:
             on_progress(

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -132,6 +132,12 @@ class _TranslateBase:
                 '--prompt-template needs to contain "{text}".'
                 " This is a placeholder for input file contents."
             )
+        if context.source_lang == context.target_lang:
+            raise ValueError(
+                f"--source_lang ({context.source_lang}) is the same as "
+                f"--target_lang ({context.target_lang}). No translation "
+                "required."
+            )
 
         try:
             config = AutoConfig.from_pretrained(
@@ -297,41 +303,56 @@ def _translate_file(
     # Detect language
     detected_lang = source_lang
     original_prompt = translator.prompt_template
-    if detected_lang is None:
-        detected_lang = detect_language(content)
+    if "{source_lang}" in translator.prompt_template:
         if detected_lang is None:
-            if use_fallback_prompt:
-                logger.warning(
-                    "  Could not detect language (text may be too short or mixed)."
-                    f" Attempting to use fallback prompt: {_FALLBACK_PROMPT}"
-                )
-                translator.prompt_template = _FALLBACK_PROMPT
+            detected_lang = detect_language(content)
+            if detected_lang is None:
+                if use_fallback_prompt:
+                    logger.warning(
+                        "  Could not detect language (text may be too short or mixed)."
+                        f" Attempting to use fallback prompt: {_FALLBACK_PROMPT}"
+                    )
+                    translator.prompt_template = _FALLBACK_PROMPT
+                else:
+                    raise TranslationError(
+                        "Could not detect language (text may be too short or mixed). "
+                        "Explicitly set --source-lang to skip language detection or run"
+                        " with --use-fallback-prompt"
+                    )
             else:
-                raise TranslationError(
-                    "Could not detect language (text may be too short or mixed). "
-                    "Explicitly set --source-lang to skip language detection or run "
-                    "with --use-fallback-prompt"
+                on_progress(
+                    f"  Detected language: {get_language_name(detected_lang)} "
+                    f"({detected_lang})"
                 )
         else:
             on_progress(
-                f"  Detected language: {get_language_name(detected_lang)} "
+                f"  Source language: {get_language_name(detected_lang)} "
                 f"({detected_lang})"
             )
-    else:
-        on_progress(
-            f"  Source language: {get_language_name(detected_lang)} ({detected_lang})"
-        )
 
-    if detected_lang == target_lang:
-        raise AlreadyInTargetLanguageError(
-            f"Already in {get_language_name(target_lang)}"
-        )
+        if detected_lang == target_lang:
+            raise AlreadyInTargetLanguageError(
+                f"Already in {get_language_name(target_lang)}"
+            )
 
-    if detected_lang and detected_lang not in LANGUAGES:
-        on_progress(
-            f"  Note: '{detected_lang}' not in common language list,"
-            " attempting anyway..."
-        )
+        if detected_lang and detected_lang not in LANGUAGES:
+            on_progress(
+                f"  Note: '{detected_lang}' not in common language list,"
+                " attempting anyway..."
+            )
+    else:  # prompt does not contain source_lang; skip lang detection
+        if source_lang:
+            logger.warning(
+                "  --prompt-template does not contain {source_lang} "
+                "but --source-lang was set. Attempting anyway using provided "
+                "prompt..."
+            )
+        else:
+            logger.warning(
+                "  --prompt-template does not contain {source_lang}. "
+                "Skipping automatic language detection and attempting translation "
+                "using provided prompt..."
+            )
 
     # Translate
     on_progress(

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -54,6 +54,11 @@ _DEFAULT_PROMPT = (
     "Output only the translated text, nothing else. Text: {text}"
 )
 
+_FALLBACK_PROMPT = (
+    "Translate the following text to {target_lang}. "
+    "Output only the translated text, nothing else. Text: {text}"
+)
+
 
 class _TranslateBase:
     """Translate documents using Hugging Face models."""
@@ -275,15 +280,25 @@ def _translate_file(
 
     # Detect language
     detected_lang = source_lang
+    original_prompt = translator.prompt_template
     if detected_lang is None:
         detected_lang = detect_language(content)
         if detected_lang is None:
-            raise TranslationError(
-                "Could not detect language (text may be too short or mixed)"
+            if translator.prompt_template == _DEFAULT_PROMPT:
+                logger.warning(
+                    "Could not detect language (text may be too short or mixed)."
+                    f" Attempting to use fallback prompt: {_FALLBACK_PROMPT}"
+                )
+                translator.prompt_template = _FALLBACK_PROMPT
+            else:
+                raise TranslationError(
+                    "Could not detect language (text may be too short or mixed)"
+                )
+        else:
+            on_progress(
+                f"  Detected language: {get_language_name(detected_lang)} "
+                f"({detected_lang})"
             )
-        on_progress(
-            f"  Detected language: {get_language_name(detected_lang)} ({detected_lang})"
-        )
     else:
         on_progress(
             f"  Source language: {get_language_name(detected_lang)} ({detected_lang})"
@@ -294,7 +309,7 @@ def _translate_file(
             f"Already in {get_language_name(target_lang)}"
         )
 
-    if detected_lang not in LANGUAGES:
+    if detected_lang and detected_lang not in LANGUAGES:
         on_progress(
             f"  Note: '{detected_lang}' not in common language list,"
             " attempting anyway..."
@@ -304,7 +319,12 @@ def _translate_file(
     on_progress(
         f"  Translating to: {get_language_name(target_lang)} ({target_lang})..."
     )
-    translated = _translate_text(content, translator, detected_lang, target_lang)
+
+    try:
+        translated = _translate_text(content, translator, detected_lang, target_lang)
+    finally:
+        if translator.prompt_template != original_prompt:  # used _FALLBACK_PROMPT
+            translator.prompt_template = original_prompt
 
     # Sanity check
     if len(translated) > 100 and detected_lang != "en":
@@ -326,7 +346,7 @@ def _translate_file(
 def _translate_text(
     text: str,
     translator: Translator,
-    source_lang: str,
+    source_lang: str | None,
     target_lang: str = "en",
     max_retries: int = 3,
 ) -> str:
@@ -370,7 +390,7 @@ def _translate_text(
 def _translate_chunk_with_retry(
     text: str,
     translator: Translator,
-    source_lang: str,
+    source_lang: str | None,
     target_lang: str,
     tokenizer: PreTrainedTokenizerBase,
     max_tokens: int,

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -127,17 +127,16 @@ class vllmTranslator:
         self, text: str, source_lang: str | None, target_lang: str
     ) -> list[dict[str, str]]:
 
-        if source_lang:
-            prompt = self.prompt_template.format(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                text=text,
+        if source_lang is None and "{source_lang}" in self.prompt_template:
+            raise ValueError(
+                "source_lang is None but prompt template requires {source_lang}. "
+                "Switch to a template without {source_lang} before translating."
             )
-        else:
-            prompt = self.prompt_template.format(
-                target_lang=target_lang,
-                text=text,
-            )
+        prompt = self.prompt_template.format(
+            source_lang=source_lang,
+            target_lang=target_lang,
+            text=text,
+        )
 
         if self.system_message:
             return [

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -23,13 +23,14 @@ class Translator(Protocol):
 
     tokenizer: PreTrainedTokenizerBase
     max_chunk_tokens: int
+    prompt_template: str
 
-    def translate(self, text: str, source_lang: str, target_lang: str) -> str:
+    def translate(self, text: str, source_lang: str | None, target_lang: str) -> str:
         """Translate a single chunk of text."""
         ...
 
     def translate_batch(
-        self, texts: list[str], source_lang: str, target_lang: str
+        self, texts: list[str], source_lang: str | None, target_lang: str
     ) -> list[str]:
         """Translate multiple chunks."""
         ...
@@ -123,13 +124,20 @@ class vllmTranslator:
         logger.info("Model loaded using vLLM!")
 
     def _build_message(
-        self, text: str, source_lang: str, target_lang: str
+        self, text: str, source_lang: str | None, target_lang: str
     ) -> list[dict[str, str]]:
-        prompt = self.prompt_template.format(
-            source_lang=source_lang,
-            target_lang=target_lang,
-            text=text,
-        )
+
+        if source_lang:
+            prompt = self.prompt_template.format(
+                source_lang=source_lang,
+                target_lang=target_lang,
+                text=text,
+            )
+        else:
+            prompt = self.prompt_template.format(
+                target_lang=target_lang,
+                text=text,
+            )
 
         if self.system_message:
             return [
@@ -138,7 +146,7 @@ class vllmTranslator:
             ]
         return [{"role": "user", "content": prompt}]
 
-    def translate(self, text: str, source_lang: str, target_lang: str) -> str:
+    def translate(self, text: str, source_lang: str | None, target_lang: str) -> str:
         message = self._build_message(text, source_lang, target_lang)
         output = self.model.chat(
             cast(Any, message),
@@ -148,7 +156,7 @@ class vllmTranslator:
         return output[0].outputs[0].text
 
     def translate_batch(
-        self, texts: list[str], source_lang: str, target_lang: str
+        self, texts: list[str], source_lang: str | None, target_lang: str
     ) -> list[str]:
         messages = [self._build_message(t, source_lang, target_lang) for t in texts]
         outputs = self.model.chat(

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -130,7 +130,7 @@ class vllmTranslator:
         if source_lang is None and "{source_lang}" in self.prompt_template:
             raise ValueError(
                 "source_lang is None but prompt template requires {source_lang}. "
-                "Switch to a template without {source_lang} before translating."
+                "Use a prompt without {source_lang} or set --source-lang."
             )
         prompt = self.prompt_template.format(
             source_lang=source_lang,

--- a/tests/unit/text/translate/test_params.py
+++ b/tests/unit/text/translate/test_params.py
@@ -19,3 +19,4 @@ def test_translate_defaults():
     assert p.llm_kwargs == "{}"
     assert p.sampling_kwargs == "{}"
     assert p.chat_kwargs == "{}"
+    assert p.use_fallback_prompt is False

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -460,14 +460,18 @@ class TestTranslateFileFallback:
         with patch(
             "tigerflow_ml.text.translate._base.detect_language", return_value=None
         ):
-            _translate_file(translator, input_file, tmp_path / "output.txt")
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "output.txt",
+                use_fallback_prompt=True,
+            )
 
         assert captured[0] == _FALLBACK_PROMPT
-
         assert translator.prompt_template == _DEFAULT_PROMPT  # prompt restored
 
-    def test_custom_prompt_raises_on_detection_failure(self, translator, tmp_path):
-        translator.prompt_template = "translate this: {text}"
+    def test_raises_on_detection_failure_by_default(self, translator, tmp_path):
+        """Default (use_fallback_prompt=False): detection failure raises with hint."""
         input_file = tmp_path / "input.txt"
         input_file.write_text("xyz")
 
@@ -475,7 +479,7 @@ class TestTranslateFileFallback:
             patch(
                 "tigerflow_ml.text.translate._base.detect_language", return_value=None
             ),
-            pytest.raises(TranslationError, match="Could not detect language"),
+            pytest.raises(TranslationError, match="--use-fallback-prompt"),
         ):
             _translate_file(translator, input_file, tmp_path / "output.txt")
 
@@ -490,6 +494,20 @@ class TestTranslateFileFallback:
             ),
             pytest.raises(TranslationError),
         ):
-            _translate_file(translator, input_file, tmp_path / "output.txt")
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "output.txt",
+                use_fallback_prompt=True,
+            )
 
         assert translator.prompt_template == _DEFAULT_PROMPT
+
+
+class TestSetupValidation:
+    def test_setup_raises_if_prompt_template_lacks_text_placeholder(self):
+        from types import SimpleNamespace
+
+        context = SimpleNamespace(prompt_template="Translate to {target_lang}.")
+        with pytest.raises(ValueError, match=r"\{text\}"):
+            _TranslateBase.setup(context)

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -333,6 +333,19 @@ class TestVllmTranslator:
         assert "hello" in user_content
         assert "en" in user_content
 
+    def test_build_message_ok_when_source_lang_provided_but_template_does_not_use_it(
+        self, mock_tokenizer
+    ):
+        translator = _make_vllm_translator(mock_tokenizer)
+        translator.prompt_template = _FALLBACK_PROMPT
+
+        messages = translator._build_message("hello", "de", "en")
+
+        user_content = messages[-1]["content"]
+        assert "hello" in user_content
+        assert "en" in user_content
+        assert "de" not in user_content
+
 
 class TestGetModelType:
     def test_tgemma_variants(self):
@@ -510,4 +523,13 @@ class TestSetupValidation:
 
         context = SimpleNamespace(prompt_template="Translate to {target_lang}.")
         with pytest.raises(ValueError, match=r"\{text\}"):
+            _TranslateBase.setup(context)
+
+    def test_setup_raises_if_source_lang_equals_target_lang(self):
+        from types import SimpleNamespace
+
+        context = SimpleNamespace(
+            source_lang="en", target_lang="en", prompt_template=_DEFAULT_PROMPT
+        )
+        with pytest.raises(ValueError, match="No translation required"):
             _TranslateBase.setup(context)

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -7,6 +7,7 @@ import pytest
 
 from tigerflow_ml.text.translate._base import (
     _DEFAULT_PROMPT,
+    _FALLBACK_PROMPT,
     _translate_chunk_with_retry,
     _translate_file,
     _translate_text,
@@ -408,3 +409,64 @@ class TestTgemmaTranslator:
 
         messages = translator.model.chat.call_args[0][0]
         assert all(m["role"] != "system" for m in messages)
+
+
+class TestTranslateFileFallback:
+    """_translate_file: language-detection fallback behaviour."""
+
+    @pytest.fixture
+    def translator(self, mock_tokenizer):
+        t = MagicMock()
+        t.tokenizer = mock_tokenizer
+        t.max_chunk_tokens = 100
+        t.prompt_template = _DEFAULT_PROMPT
+        t.translate.return_value = "translated content"
+        return t
+
+    def test_fallback_prompt_used_during_translation(self, translator, tmp_path):
+        input_file = tmp_path / "input.txt"
+        input_file.write_text("xyz")
+        captured = []
+
+        def capture(*args, **kwargs):
+            captured.append(translator.prompt_template)
+            return "translated content"
+
+        translator.translate.side_effect = capture
+
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            _translate_file(translator, input_file, tmp_path / "output.txt")
+
+        assert captured[0] == _FALLBACK_PROMPT
+
+        assert translator.prompt_template == _DEFAULT_PROMPT  # prompt restored
+
+    def test_custom_prompt_raises_on_detection_failure(self, translator, tmp_path):
+        translator.prompt_template = "translate this: {text}"
+        input_file = tmp_path / "input.txt"
+        input_file.write_text("xyz")
+
+        with (
+            patch(
+                "tigerflow_ml.text.translate._base.detect_language", return_value=None
+            ),
+            pytest.raises(TranslationError, match="Could not detect language"),
+        ):
+            _translate_file(translator, input_file, tmp_path / "output.txt")
+
+    def test_prompt_restored_even_if_translation_fails(self, translator, tmp_path):
+        input_file = tmp_path / "input.txt"
+        input_file.write_text("xyz")
+        translator.translate.side_effect = TranslationError("model error")
+
+        with (
+            patch(
+                "tigerflow_ml.text.translate._base.detect_language", return_value=None
+            ),
+            pytest.raises(TranslationError),
+        ):
+            _translate_file(translator, input_file, tmp_path / "output.txt")
+
+        assert translator.prompt_template == _DEFAULT_PROMPT

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -310,6 +310,29 @@ class TestVllmTranslator:
         messages = translator.model.chat.call_args[0][0]
         assert messages[0]["content"] == custom_msg
 
+    def test_build_message_raises_when_source_lang_none_and_template_requires_it(
+        self, mock_tokenizer
+    ):
+        """ValueError if source_lang is None but the template contains {source_lang}."""
+        translator = _make_vllm_translator(mock_tokenizer)
+        assert "{source_lang}" in translator.prompt_template
+
+        with pytest.raises(ValueError, match="source_lang is None"):
+            translator._build_message("hello", None, "en")
+
+    def test_build_message_ok_when_source_lang_none_and_template_does_not_require_it(
+        self, mock_tokenizer
+    ):
+        """No error when source_lang is None and the template omits {source_lang}."""
+        translator = _make_vllm_translator(mock_tokenizer)
+        translator.prompt_template = _FALLBACK_PROMPT
+
+        messages = translator._build_message("hello", None, "en")
+
+        user_content = messages[-1]["content"]
+        assert "hello" in user_content
+        assert "en" in user_content
+
 
 class TestGetModelType:
     def test_tgemma_variants(self):


### PR DESCRIPTION
### Changes:

- Adds argument `use_fallback_prompt` which allows use of a fallback prompt if automatic language detection fails:

     "Translate the following text to {target_lang}. Output only the translated text, nothing else. Text: {text}"

- Automatic language detection is avoided if `"{source_lang}"` is not in the provided `prompt-template`
- Validates that `"{text}"` is in the `prompt-template` at setup time
- Validates that `source-lang` is not the same as `target-lang` at setup time

### Related issues:

- #37 
- #62 
- #67 
- #66 

### Open question:

The current design decision is to skip automatic language detection altogether if `"{source_lang}"` is not in the provided `prompt-template`. This has two consequences:
- If a `source-langauge` is not provided by the user, the source languages of the files will not be logged
- there is no check to see if an input file is already in the target language (I imagine this would result in a model output like: "the provided text is already in {target_lang}")

It might be better to automatically detect the language regardless, even if it is potential unnecessary, to avoid these. I think this could be potentially problematic in the case where an input file is multilingual. 