### PR TITLE
feat: validate prompt-template and source/target lang at setup

### DIFF
--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -111,6 +111,17 @@ class _TranslateBase:
 
         from .translator import build_translator
 
+        if "{text}" not in context.prompt_template:
+            raise ValueError(
+                '--prompt-template must contain "{text}"'
+                " as a placeholder for input file contents."
+            )
+        if context.source_lang == context.target_lang:
+            raise ValueError(
+                f"--source-lang ({context.source_lang}) is the same as"
+                f" --target-lang ({context.target_lang}). No translation required."
+            )
+
         try:
             config = AutoConfig.from_pretrained(
                 context.model,

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -408,3 +408,23 @@ class TestTgemmaTranslator:
 
         messages = translator.model.chat.call_args[0][0]
         assert all(m["role"] != "system" for m in messages)
+
+
+class TestSetupValidation:
+    def test_setup_raises_if_prompt_template_lacks_text_placeholder(self):
+        context = SimpleNamespace(
+            prompt_template="Translate to {target_lang}.",
+            source_lang="fr",
+            target_lang="en",
+        )
+        with pytest.raises(ValueError, match=r"\{text\}"):
+            _TranslateBase.setup(context)
+
+    def test_setup_raises_if_source_lang_equals_target_lang(self):
+        context = SimpleNamespace(
+            prompt_template=_DEFAULT_PROMPT,
+            source_lang="en",
+            target_lang="en",
+        )
+        with pytest.raises(ValueError, match="No translation required"):
+            _TranslateBase.setup(context)


### PR DESCRIPTION
## Summary

Adds two setup-time validation checks for the translate task:

1. `--prompt-template` must contain the `{text}` placeholder
2. `--source-lang` must differ from `--target-lang`

Both errors are raised before the model is loaded, so users see clear feedback rather than a confusing downstream failure.

Extracted from #73 (closed) as part of splitting that work into three smaller, independently reviewable PRs. Authored by @Nina-mvH.

Closes #67

## Test plan
- [x] Unit tests pass locally on Linux (150 passed, 14 skipped)
- [x] CI passes