### PR TITLE
feat: add --auto-lang-detect flag

### DIFF
--- a/docs/mkdocs/tasks/translate.md
+++ b/docs/mkdocs/tasks/translate.md
@@ -10,8 +10,9 @@ Translate text documents using HuggingFace [vLLM optimized TranslateGemma](https
 | `--revision`         | `main`                           | Model revision (branch, tag, or commit hash)                                                                                     |
 | `--cache-dir`        |                                  | HuggingFace cache directory for model files (equivalent to `HF_HOME`)                                                            |
 | `--allow-fetch`      | `--no-allow-fetch`               | Allow downloads from HuggingFace Hub (network access required)                                                                   |
-| `--source-lang`      |                                  | Source language code (e.g. `en`, `de`, `zh`) -- will attempt auto detection by default                                           |
+| `--source-lang`      |                                  | Source language code (e.g. `en`, `de`, `zh`). Overrides auto-detection when `--auto-lang-detect` is on.                          |
 | `--target-lang`      | `en`                             | Target language code (e.g. `de`, `en`, `fr`)                                                                                     |
+| `--auto-lang-detect` | `True`                           | Auto-detect source language with `langdetect`. When disabled (`--no-auto-lang-detect`), `--source-lang` is required.             |
 | `--chunk-size`       | `900`                            | Maximum input tokens per chunk                                                                                                   |
 | `--max-model-len`    | `chunk_size × 2.5 + 512`         | Maximum sequence length (input + output tokens) passed to vLLM. Capped by the model's configured context window.                 |
 | `--model-backend`    | `auto`                           | Model backend: `chat`, `tgemma`, or `auto` (auto-detects from model name)                                                        |
@@ -19,9 +20,9 @@ Translate text documents using HuggingFace [vLLM optimized TranslateGemma](https
 | `--system-message`   |                                  | System message for chat models. Ignored for tgemma models.                                                                       |
 | `--temperature`      | `0.0`                            | Sampling temperature. Lower values make output more deterministic.                                                               |
 | `--seed`             | `42`                             | Random seed for reproducibility                                                                                                  |
-| `--llm-kwargs`       | `{}`                             | JSON string of extra kwargs for vLLM's `LLM()` constructor. Overrides task defaults.        |
-| `--sampling-kwargs`  | `{}`                             | JSON string of extra kwargs for vLLM's `SamplingParams()`. Overrides task defaults.                 |
-| `--chat-kwargs`      | `{}`                             | JSON string of extra kwargs for `LLM.chat()`. Overrides task defaults.                           |
+| `--llm-kwargs`       | `{}`                             | JSON string of extra kwargs for vLLM's `LLM()` constructor. Overrides task defaults.                                             |
+| `--sampling-kwargs`  | `{}`                             | JSON string of extra kwargs for vLLM's `SamplingParams()`. Overrides task defaults.                                              |
+| `--chat-kwargs`      | `{}`                             | JSON string of extra kwargs for `LLM.chat()`. Overrides task defaults.                                                           |
 
 
 ## Chunking Strategy

--- a/src/tigerflow_ml/text/translate/README.md
+++ b/src/tigerflow_ml/text/translate/README.md
@@ -4,7 +4,7 @@ Translate `.txt` documents into English (or another target language) using any c
 
 ## How it works
 
-1. The source language for each `.txt` file in the input directory is detected via `langdetect` (or supplied with `--source-lang`).
+1. The source language for each `.txt` file is resolved using the provided `--source-lang` or autodetection via `langdetect` (unless `--auto-lang-detect` is disabled).
 2. If the document exceeds the token budget, it is split into chunks at paragraph and/or sentence boundaries.
 3. Each chunk is translated via vLLM.
 4. Translated chunks are reassembled and written to the output directory.
@@ -62,7 +62,8 @@ Here's a breakdown of what each of these arguments does:
 
 Some other arguments you can use are:
 
-- `--source-lang` : Source language code (e.g. 'en', 'de', 'zh'). If this is not specified, the input files' language is detected via `langdetect`.
+- `--source-lang` : Source language code (e.g. 'en', 'de', 'zh'). Overrides auto-detection when `--auto-lang-detect` is on.
+- `--auto-lang-detect` / `--no-auto-lang-detect` : Whether to auto-detect the source language via `langdetect` (default: on). When enabled alongside `--source-lang`, detection still runs, but `--source-lang` takes precedence.
 - `--target-lang` : Target language code (e.g. 'de', 'en', 'fr'). This defaults to English (en).
 - `--chunk-size` : The maximum tokens per chunk. The documents are translated one chunk at a time, so if your model cannot handle large inputs, this should be small. Defaults to `900`.
 - `--max-model-len` : Maximum sequence length (input + output tokens) passed to vLLM. Defaults to `chunk_size * 2.5 + 512`, capped by the model's configured context window.

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -89,6 +89,14 @@ class _TranslateBase:
             typer.Option(help="Translation model backend. 'auto' uses model name."),
         ] = "auto"
 
+        auto_lang_detect: Annotated[
+            bool,
+            typer.Option(
+                help="Auto-detect source language with langdetect. "
+                "When disabled, --source-lang is required."
+            ),
+        ] = True
+
         # override for custom help message
         max_model_len: Annotated[
             int | None,
@@ -182,6 +190,7 @@ class _TranslateBase:
             context.source_lang,
             context.target_lang,
             logger.info,
+            auto_lang_detect=context.auto_lang_detect,
         )
 
         logger.info("Translation complete!")
@@ -249,6 +258,75 @@ def _download_tokenizer(
     )
 
 
+def _resolve_source_lang(
+    content: str,
+    source_lang: str | None,
+    target_lang: str,
+    auto_lang_detect: bool,
+    on_progress: Callable[..., None],
+) -> str:
+    """
+    Resolve the source language for a file.
+
+    Explicit source_lang always takes precedence. When auto_lang_detect is
+    True, langdetect fills in a missing source_lang and a mismatch between
+    detected and given is warned about.
+
+    Args:
+        content: File contents (used for detection).
+        source_lang: Explicit source language code, or None.
+        target_lang: Target language code.
+        auto_lang_detect: Whether to run langdetect.
+        on_progress: Callback for progress messages.
+
+    Returns:
+        Resolved source language code.
+
+    Raises:
+        AlreadyInTargetLanguageError: If resolved language equals target_lang.
+        TranslationError: If no source language can be determined.
+    """
+    if not auto_lang_detect:
+        if source_lang is None:
+            raise TranslationError(
+                "Source language could not be determined. "
+                "Explicitly set --source-lang or enable --auto-lang-detect."
+            )
+        on_progress(
+            f"  Source language: {get_language_name(source_lang)} ({source_lang})"
+        )
+        resolved = source_lang
+    else:
+        detected = detect_language(content)
+        if detected is not None:
+            on_progress(
+                f"  Detected language: {get_language_name(detected)} ({detected})"
+            )
+        if source_lang is not None:
+            on_progress(
+                f"  Source language: {get_language_name(source_lang)} ({source_lang})"
+            )
+            if detected is not None and detected != source_lang:
+                on_progress(
+                    f"  Warning: detected {detected} but --source-lang is"
+                    f" {source_lang}; using --source-lang"
+                )
+            resolved = source_lang
+        elif detected is not None:
+            resolved = detected
+        else:
+            raise TranslationError(
+                "Could not detect language (text may be too short or mixed). "
+                "Explicitly set --source-lang."
+            )
+
+    if resolved == target_lang:
+        raise AlreadyInTargetLanguageError(
+            f"Already in {get_language_name(target_lang)}"
+        )
+    return resolved
+
+
 def _translate_file(
     translator: Translator,
     input_file: Path,
@@ -256,6 +334,7 @@ def _translate_file(
     source_lang: str | None = None,
     target_lang: str = "en",
     on_progress: Callable[..., None] = print,
+    auto_lang_detect: bool = True,
 ) -> str:
     """
     Translate a single file.
@@ -264,9 +343,12 @@ def _translate_file(
         translator: Translator instance.
         input_file: Path to input file.
         output_file: Path to output file.
-        source_lang: Source language code (auto-detect if None).
+        source_lang: Source language code. Required when auto_lang_detect is
+            False; otherwise overrides auto-detection if provided.
         target_lang: Target language code.
         on_progress: Callback for progress messages.
+        auto_lang_detect: Run langdetect on the file. Explicit source_lang
+            takes precedence; when False, source_lang is required.
 
     Raises:
         EmptyFileError: If the input file is empty.
@@ -282,30 +364,13 @@ def _translate_file(
 
     on_progress(f"  File size: {len(content):,} characters")
 
-    # Detect language
-    detected_lang = source_lang
-    if detected_lang is None:
-        detected_lang = detect_language(content)
-        if detected_lang is None:
-            raise TranslationError(
-                "Could not detect language (text may be too short or mixed)"
-            )
-        on_progress(
-            f"  Detected language: {get_language_name(detected_lang)} ({detected_lang})"
-        )
-    else:
-        on_progress(
-            f"  Source language: {get_language_name(detected_lang)} ({detected_lang})"
-        )
+    resolved_lang = _resolve_source_lang(
+        content, source_lang, target_lang, auto_lang_detect, on_progress
+    )
 
-    if detected_lang == target_lang:
-        raise AlreadyInTargetLanguageError(
-            f"Already in {get_language_name(target_lang)}"
-        )
-
-    if detected_lang not in LANGUAGES:
+    if resolved_lang not in LANGUAGES:
         on_progress(
-            f"  Note: '{detected_lang}' not in common language list,"
+            f"  Note: '{resolved_lang}' not in common language list,"
             " attempting anyway..."
         )
 
@@ -313,10 +378,10 @@ def _translate_file(
     on_progress(
         f"  Translating to: {get_language_name(target_lang)} ({target_lang})..."
     )
-    translated = _translate_text(content, translator, detected_lang, target_lang)
+    translated = _translate_text(content, translator, resolved_lang, target_lang)
 
     # Sanity check
-    if len(translated) > 100 and detected_lang != "en":
+    if len(translated) > 100 and resolved_lang != "en":
         if content[:100] == translated[:100]:
             on_progress(
                 "  Warning: Output appears identical to input -"

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -195,6 +195,113 @@ class TestTranslateFile:
                 _translate_file(MagicMock(), input_file, tmp_path / "out.txt")
 
 
+class TestTranslateFileAutoLangDetect:
+    """_translate_file: auto_lang_detect / source_lang interaction."""
+
+    @pytest.fixture
+    def translator(self, mock_translator):
+        mock_translator.translate.return_value = "translated content"
+        return mock_translator
+
+    def test_source_lang_overrides_detected(self, translator, tmp_path):
+        """Explicit --source-lang wins over auto-detected language."""
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Bonjour le monde")
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value="es"
+        ):
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                source_lang="fr",
+                target_lang="en",
+            )
+        assert translator.translate.call_args.args[1] == "fr"
+
+    def test_detection_failure_with_source_lang_succeeds(self, translator, tmp_path):
+        """Detection failure is non-fatal when --source-lang is explicitly set."""
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Bonjour le monde")
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                source_lang="fr",
+                target_lang="en",
+            )
+        translator.translate.assert_called_once()
+        assert translator.translate.call_args.args[1] == "fr"
+
+    def test_auto_lang_detect_disabled_skips_detection(self, translator, tmp_path):
+        """auto_lang_detect=False never calls detect_language."""
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Bonjour le monde")
+        with patch("tigerflow_ml.text.translate._base.detect_language") as mock_detect:
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                source_lang="fr",
+                target_lang="en",
+                auto_lang_detect=False,
+            )
+        mock_detect.assert_not_called()
+
+    def test_auto_lang_detect_disabled_no_source_lang_raises(
+        self, translator, tmp_path
+    ):
+        """auto_lang_detect=False + no source_lang -> TranslationError."""
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Bonjour le monde")
+        with pytest.raises(TranslationError, match="--auto-lang-detect"):
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                auto_lang_detect=False,
+            )
+
+    def test_source_lang_equals_target_raises_even_when_detected_differs(
+        self, translator, tmp_path
+    ):
+        """Explicit source_lang wins, so source_lang==target_lang trips the check."""
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("Hello world")
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value="fr"
+        ):
+            with pytest.raises(AlreadyInTargetLanguageError):
+                _translate_file(
+                    translator,
+                    input_file,
+                    tmp_path / "out.txt",
+                    source_lang="en",
+                    target_lang="en",
+                )
+
+    def test_explicit_source_lang_avoids_already_in_target_when_detected_matches(
+        self, translator, tmp_path
+    ):
+        """Detected=='en' would normally raise, but user said --source-lang=fr."""
+        input_file = tmp_path / "doc.txt"
+        input_file.write_text("ambiguous")
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value="en"
+        ):
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                source_lang="fr",
+                target_lang="en",
+            )
+        assert translator.translate.call_args.args[1] == "fr"
+
+
 class TestRun:
     @pytest.mark.parametrize(
         "error",
@@ -206,7 +313,10 @@ class TestRun:
     )
     def test_run_propagates_translate_file_errors(self, tmp_path, error):
         context = SimpleNamespace(
-            translator=MagicMock(), source_lang=None, target_lang="en"
+            translator=MagicMock(),
+            source_lang=None,
+            target_lang="en",
+            auto_lang_detect=True,
         )
         with patch(
             "tigerflow_ml.text.translate._base._translate_file", side_effect=error


### PR DESCRIPTION
**Depends on #78** — will rebase onto main after that lands.

## Summary

Adds an opt-out toggle for langdetect:

- When enabled (default), explicit `--source-lang` takes precedence over the detected language; a mismatch between the two is logged as a warning.
- When disabled, `--source-lang` is required (regardless of whether the active prompt template references `{source_lang}` — that relaxation lands in a follow-up PR alongside `--use-fallback-prompt`).

Extracts the resolution logic into a `_resolve_source_lang` helper to keep `_translate_file` linear.

Extracted from #73 (closed) as part of splitting that work into three smaller, independently reviewable PRs. Authored by @Nina-mvH.

### Divergence from #73

When the user supplies `--source-lang` and auto-detection returns `target_lang`, this implementation trusts the user and proceeds with translation. #73's implementation raised `AlreadyInTargetLanguageError` off the detected value before applying the user override. (This scenario doesn't arise on `main`, where `source_lang` short-circuits detection entirely.)

## Test plan
- [x] Unit tests pass locally on Linux (150 passed, 14 skipped)
- [x] CI passes