### PR TITLE
feat: add --use-fallback-prompt for missing source language

### DIFF
--- a/docs/mkdocs/tasks/translate.md
+++ b/docs/mkdocs/tasks/translate.md
@@ -17,6 +17,7 @@ Translate text documents using HuggingFace [vLLM optimized TranslateGemma](https
 | `--max-model-len`    | `chunk_size × 2.5 + 512`         | Maximum sequence length (input + output tokens) passed to vLLM. Capped by the model's configured context window.                 |
 | `--model-backend`    | `auto`                           | Model backend: `chat`, `tgemma`, or `auto` (auto-detects from model name)                                                        |
 | `--prompt-template`  | *(see below)*                    | Prompt template for chat-based models (uses `{source_lang}`, `{target_lang}`, and `{text}`). Ignored for tgemma models.          |
+| `--use-fallback-prompt` | `False`                       | When no source language can be determined and the prompt template uses `{source_lang}`, fall back to a source-language-free prompt (`Translate the following text to {target_lang}…`). Not supported for `tgemma` models. |
 | `--system-message`   |                                  | System message for chat models. Ignored for tgemma models.                                                                       |
 | `--temperature`      | `0.0`                            | Sampling temperature. Lower values make output more deterministic.                                                               |
 | `--seed`             | `42`                             | Random seed for reproducibility                                                                                                  |

--- a/src/tigerflow_ml/text/translate/README.md
+++ b/src/tigerflow_ml/text/translate/README.md
@@ -73,6 +73,7 @@ Some other arguments you can use are:
 - `--cache-dir` : The HuggingFace cache directory for model files. This is equivalent to specifying the path via `HF_HOME` in a `--setup-command`, though you need to specify the path to `.hf/hub/`.
 - `--model-backend` : Specifies which translation model backend will be used. By default, this will auto-detect whether a TranslateGemma model is being used -- all other models will use the `chat` backend via vLLM.
 - `--prompt-template` : (**not used for tgemma models**) Prompt template for chat-based translation models. Defaults to `Translate the following text from {source_lang} to {target_lang}. Output only the translated text, nothing else. Text: {text}`.
+- `--use-fallback-prompt` : (**not used for tgemma models**) When no source language can be determined and the prompt template uses `{source_lang}`, swap to a source-language-free fallback prompt (`Translate the following text to {target_lang}. Output only the translated text, nothing else. Text: {text}`) for that file instead of raising an error. Disabled by default.
 - `--system-message` : (**not used for tgemma models**) Optional system message for chat models.
 - `--temperature` : Sampling temperature. Lower values make output more deterministic. Defaults to `0.0`.
 - `--seed` : Random seed for reproducibility. Defaults to `42`.

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -51,6 +51,11 @@ _DEFAULT_PROMPT = (
     "Output only the translated text, nothing else. Text: {text}"
 )
 
+_FALLBACK_PROMPT = (
+    "Translate the following text to {target_lang}. "
+    "Output only the translated text, nothing else. Text: {text}"
+)
+
 
 class _TranslateBase:
     """Translate documents using Hugging Face models."""
@@ -96,6 +101,15 @@ class _TranslateBase:
                 "When disabled, --source-lang is required."
             ),
         ] = True
+
+        use_fallback_prompt: Annotated[
+            bool,
+            typer.Option(
+                help="Use a source-language-free fallback prompt when "
+                "no source language can be determined. Not supported for "
+                "tgemma models."
+            ),
+        ] = False
 
         # override for custom help message
         max_model_len: Annotated[
@@ -191,6 +205,7 @@ class _TranslateBase:
             context.target_lang,
             logger.info,
             auto_lang_detect=context.auto_lang_detect,
+            use_fallback_prompt=context.use_fallback_prompt,
         )
 
         logger.info("Translation complete!")
@@ -264,13 +279,14 @@ def _resolve_source_lang(
     target_lang: str,
     auto_lang_detect: bool,
     on_progress: Callable[..., None],
-) -> str:
+) -> str | None:
     """
     Resolve the source language for a file.
 
     Explicit source_lang always takes precedence. When auto_lang_detect is
     True, langdetect fills in a missing source_lang and a mismatch between
-    detected and given is warned about.
+    detected and given is warned about. Returns None when no source language
+    can be determined; the caller decides whether that's an error.
 
     Args:
         content: File contents (used for detection).
@@ -280,11 +296,11 @@ def _resolve_source_lang(
         on_progress: Callback for progress messages.
 
     Returns:
-        Resolved source language code.
+        Resolved source language code, or None if unresolvable.
 
     Raises:
         AlreadyInTargetLanguageError: If resolved language equals target_lang.
-        TranslationError: If no source language can be determined.
+        TranslationError: If auto_lang_detect is False and source_lang is None.
     """
     if not auto_lang_detect:
         if source_lang is None:
@@ -295,7 +311,7 @@ def _resolve_source_lang(
         on_progress(
             f"  Source language: {get_language_name(source_lang)} ({source_lang})"
         )
-        resolved = source_lang
+        resolved: str | None = source_lang
     else:
         detected = detect_language(content)
         if detected is not None:
@@ -312,15 +328,10 @@ def _resolve_source_lang(
                     f" {source_lang}; using --source-lang"
                 )
             resolved = source_lang
-        elif detected is not None:
-            resolved = detected
         else:
-            raise TranslationError(
-                "Could not detect language (text may be too short or mixed). "
-                "Explicitly set --source-lang."
-            )
+            resolved = detected
 
-    if resolved == target_lang:
+    if resolved is not None and resolved == target_lang:
         raise AlreadyInTargetLanguageError(
             f"Already in {get_language_name(target_lang)}"
         )
@@ -335,6 +346,7 @@ def _translate_file(
     target_lang: str = "en",
     on_progress: Callable[..., None] = print,
     auto_lang_detect: bool = True,
+    use_fallback_prompt: bool = False,
 ) -> str:
     """
     Translate a single file.
@@ -349,12 +361,18 @@ def _translate_file(
         on_progress: Callback for progress messages.
         auto_lang_detect: Run langdetect on the file. Explicit source_lang
             takes precedence; when False, source_lang is required.
+        use_fallback_prompt: When no source language can be determined and
+            the translator's prompt template requires {source_lang}, swap to
+            a source-language-free fallback prompt for this file. Not
+            supported for tgemma models.
 
     Raises:
         EmptyFileError: If the input file is empty.
         AlreadyInTargetLanguageError: If the input file is already 'translated.'
         TranslationError: If translation fails.
     """
+    from .translator import TgemmaTranslator
+
     on_progress(f"Processing: {input_file.name}")
 
     content = read_file_with_fallback(input_file)
@@ -368,17 +386,41 @@ def _translate_file(
         content, source_lang, target_lang, auto_lang_detect, on_progress
     )
 
-    if resolved_lang not in LANGUAGES:
+    original_prompt = translator.prompt_template
+    use_fallback = False
+
+    if resolved_lang is None:
+        if isinstance(translator, TgemmaTranslator):
+            raise TranslationError(
+                "Source language could not be determined. Explicitly set --source-lang."
+            )
+        if "{source_lang}" in original_prompt:
+            if not use_fallback_prompt:
+                raise TranslationError(
+                    "Source language could not be determined. "
+                    "Explicitly set --source-lang or run with"
+                    " --use-fallback-prompt."
+                )
+            on_progress(f"  Using fallback prompt: {_FALLBACK_PROMPT}")
+            use_fallback = True
+
+    if resolved_lang is not None and resolved_lang not in LANGUAGES:
         on_progress(
             f"  Note: '{resolved_lang}' not in common language list,"
             " attempting anyway..."
         )
 
-    # Translate
     on_progress(
         f"  Translating to: {get_language_name(target_lang)} ({target_lang})..."
     )
-    translated = _translate_text(content, translator, resolved_lang, target_lang)
+
+    try:
+        if use_fallback:
+            translator.prompt_template = _FALLBACK_PROMPT
+        translated = _translate_text(content, translator, resolved_lang, target_lang)
+    finally:
+        if use_fallback:
+            translator.prompt_template = original_prompt
 
     # Sanity check
     if len(translated) > 100 and resolved_lang != "en":
@@ -400,7 +442,7 @@ def _translate_file(
 def _translate_text(
     text: str,
     translator: Translator,
-    source_lang: str,
+    source_lang: str | None,
     target_lang: str = "en",
     max_retries: int = 3,
 ) -> str:
@@ -444,7 +486,7 @@ def _translate_text(
 def _translate_chunk_with_retry(
     text: str,
     translator: Translator,
-    source_lang: str,
+    source_lang: str | None,
     target_lang: str,
     tokenizer: PreTrainedTokenizerBase,
     max_tokens: int,

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -23,13 +23,14 @@ class Translator(Protocol):
 
     tokenizer: PreTrainedTokenizerBase
     max_chunk_tokens: int
+    prompt_template: str
 
-    def translate(self, text: str, source_lang: str, target_lang: str) -> str:
+    def translate(self, text: str, source_lang: str | None, target_lang: str) -> str:
         """Translate a single chunk of text."""
         ...
 
     def translate_batch(
-        self, texts: list[str], source_lang: str, target_lang: str
+        self, texts: list[str], source_lang: str | None, target_lang: str
     ) -> list[str]:
         """Translate multiple chunks."""
         ...
@@ -127,8 +128,13 @@ class vllmTranslator:
         logger.info("Model loaded using vLLM!")
 
     def _build_message(
-        self, text: str, source_lang: str, target_lang: str
+        self, text: str, source_lang: str | None, target_lang: str
     ) -> list[dict[str, str]]:
+        if source_lang is None and "{source_lang}" in self.prompt_template:
+            raise ValueError(
+                "source_lang is None but prompt template requires {source_lang}. "
+                "Use a prompt without {source_lang} or set --source-lang."
+            )
         prompt = self.prompt_template.format(
             source_lang=source_lang,
             target_lang=target_lang,
@@ -142,7 +148,7 @@ class vllmTranslator:
             ]
         return [{"role": "user", "content": prompt}]
 
-    def translate(self, text: str, source_lang: str, target_lang: str) -> str:
+    def translate(self, text: str, source_lang: str | None, target_lang: str) -> str:
         message = self._build_message(text, source_lang, target_lang)
         output = self.model.chat(
             cast(Any, message),
@@ -152,7 +158,7 @@ class vllmTranslator:
         return output[0].outputs[0].text
 
     def translate_batch(
-        self, texts: list[str], source_lang: str, target_lang: str
+        self, texts: list[str], source_lang: str | None, target_lang: str
     ) -> list[str]:
         messages = [self._build_message(t, source_lang, target_lang) for t in texts]
         outputs = self.model.chat(

--- a/tests/unit/text/translate/test_translation.py
+++ b/tests/unit/text/translate/test_translation.py
@@ -7,6 +7,7 @@ import pytest
 
 from tigerflow_ml.text.translate._base import (
     _DEFAULT_PROMPT,
+    _FALLBACK_PROMPT,
     _translate_chunk_with_retry,
     _translate_file,
     _translate_text,
@@ -46,6 +47,7 @@ def mock_translator(mock_tokenizer):
     translator = MagicMock()
     translator.tokenizer = mock_tokenizer
     translator.max_chunk_tokens = 10
+    translator.prompt_template = _DEFAULT_PROMPT
     return translator
 
 
@@ -185,14 +187,14 @@ class TestTranslateFile:
                     MagicMock(), input_file, tmp_path / "out.txt", target_lang="en"
                 )
 
-    def test_language_detection_fails_raises(self, tmp_path):
+    def test_language_detection_fails_raises(self, mock_translator, tmp_path):
         input_file = tmp_path / "doc.txt"
         input_file.write_text("Hello world")
         with patch(
             "tigerflow_ml.text.translate._base.detect_language", return_value=None
         ):
             with pytest.raises(TranslationError):
-                _translate_file(MagicMock(), input_file, tmp_path / "out.txt")
+                _translate_file(mock_translator, input_file, tmp_path / "out.txt")
 
 
 class TestTranslateFileAutoLangDetect:
@@ -302,6 +304,132 @@ class TestTranslateFileAutoLangDetect:
         assert translator.translate.call_args.args[1] == "fr"
 
 
+class TestTranslateFileFallback:
+    """_translate_file: --use-fallback-prompt routing."""
+
+    def test_fallback_prompt_reaches_model_when_detection_fails(
+        self, mock_tokenizer, tmp_path
+    ):
+        """When detection fails and fallback is enabled, the model.chat
+        payload uses _FALLBACK_PROMPT (not the default {source_lang} prompt).
+        """
+        translator = _make_vllm_translator(mock_tokenizer)
+        translator.model.chat.return_value = [_vllm_output("translated")]
+        input_file = tmp_path / "in.txt"
+        input_file.write_text("xyz")
+
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                target_lang="en",
+                use_fallback_prompt=True,
+            )
+
+        sent = translator.model.chat.call_args[0][0][-1]["content"]
+        assert sent == _FALLBACK_PROMPT.format(target_lang="en", text="xyz")
+
+    def test_prompt_template_restored_after_translation_exception(
+        self, mock_tokenizer, tmp_path
+    ):
+        """try/finally restores prompt_template if translation raises.
+
+        Note: this test exercises the mutate-restore pattern in
+        _translate_file and should be removed alongside that pattern in the
+        follow-up refactor that threads prompt_template through translate().
+        """
+        translator = _make_vllm_translator(mock_tokenizer)
+        translator.model.chat.side_effect = RuntimeError("boom")
+        input_file = tmp_path / "in.txt"
+        input_file.write_text("xyz")
+
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            with pytest.raises(RuntimeError):
+                _translate_file(
+                    translator,
+                    input_file,
+                    tmp_path / "out.txt",
+                    target_lang="en",
+                    use_fallback_prompt=True,
+                )
+
+        assert translator.prompt_template == _DEFAULT_PROMPT
+
+    def test_no_source_lang_in_template_translates_without_fallback(
+        self, mock_tokenizer, tmp_path
+    ):
+        """When the active template doesn't reference {source_lang},
+        detection failure is non-fatal and the custom template (not the
+        fallback) reaches the model."""
+        custom_template = "Render in {target_lang}: {text}"
+        translator = _make_vllm_translator(mock_tokenizer)
+        translator.prompt_template = custom_template
+        translator.model.chat.return_value = [_vllm_output("translated")]
+        input_file = tmp_path / "in.txt"
+        input_file.write_text("xyz")
+
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            _translate_file(
+                translator,
+                input_file,
+                tmp_path / "out.txt",
+                target_lang="en",
+                use_fallback_prompt=False,
+            )
+
+        sent = translator.model.chat.call_args[0][0][-1]["content"]
+        assert sent == custom_template.format(target_lang="en", text="xyz")
+        assert translator.prompt_template == custom_template
+
+
+class TestTranslateFileTgemma:
+    """_translate_file: tgemma models reject the fallback path."""
+
+    def _make_tgemma(self, mock_tokenizer):
+        translator = object.__new__(TgemmaTranslator)
+        translator.tokenizer = mock_tokenizer
+        translator.max_chunk_tokens = 5
+        translator.sampling_params = MagicMock()
+        translator.extra_chat_kwargs = {"use_tqdm": False}
+        translator.prompt_template = (
+            "<<<source>>>{source_lang}<<<target>>>{target_lang}<<<text>>>{text}"
+        )
+        translator.system_message = None
+        translator.model = MagicMock()
+        return translator
+
+    def test_tgemma_raises_even_when_use_fallback_prompt_enabled(
+        self, mock_tokenizer, tmp_path
+    ):
+        """tgemma ignores use_fallback_prompt and requires a source language.
+        Its prompt_template stays untouched."""
+        translator = self._make_tgemma(mock_tokenizer)
+        original_prompt = translator.prompt_template
+        input_file = tmp_path / "in.txt"
+        input_file.write_text("xyz")
+
+        with patch(
+            "tigerflow_ml.text.translate._base.detect_language", return_value=None
+        ):
+            with pytest.raises(TranslationError):
+                _translate_file(
+                    translator,
+                    input_file,
+                    tmp_path / "out.txt",
+                    target_lang="en",
+                    use_fallback_prompt=True,
+                )
+
+        assert translator.prompt_template == original_prompt
+
+
 class TestRun:
     @pytest.mark.parametrize(
         "error",
@@ -317,6 +445,7 @@ class TestRun:
             source_lang=None,
             target_lang="en",
             auto_lang_detect=True,
+            use_fallback_prompt=False,
         )
         with patch(
             "tigerflow_ml.text.translate._base._translate_file", side_effect=error
@@ -418,6 +547,16 @@ class TestVllmTranslator:
 
         messages = translator.model.chat.call_args[0][0]
         assert messages[0]["content"] == custom_msg
+
+    def test_build_message_raises_when_source_lang_none_and_template_requires_it(
+        self, mock_tokenizer
+    ):
+        """Guard the new None input space opened by widening source_lang."""
+        translator = _make_vllm_translator(mock_tokenizer)
+        assert "{source_lang}" in translator.prompt_template
+
+        with pytest.raises(ValueError, match="source_lang"):
+            translator._build_message("hello", None, "en")
 
 
 class TestGetModelType:


### PR DESCRIPTION
**Depends on #78 and #79** — will rebase onto main after those land.

## Summary

When no source language can be resolved (neither user-provided nor auto-detected) and the active prompt template requires `{source_lang}`, `--use-fallback-prompt` swaps in a source-language-free prompt for that file only. tgemma models are excluded — their training assumes a real source language code.

Also widens `Translator.translate`/`translate_batch` `source_lang` to `str | None` and adds `prompt_template` to the protocol. Guards `vllmTranslator._build_message` against the new `None` + `{source_lang}`-in-template combination.

Extracted from #73 (closed) as part of splitting that work into three smaller, independently reviewable PRs. Authored by @Nina-mvH.

### Known code smell — follow-up planned

This PR preserves the mutate-restore pattern on `translator.prompt_template` via `try/finally`. The translator's behavior depends on transient state set by its caller, which is the kind of coupling we want to avoid.

A follow-up will thread `prompt_template` through `translate()` as a parameter, eliminating the mutation and dropping `prompt_template` from the protocol. The restoration test (`test_prompt_template_restored_after_translation_exception`) is flagged for removal in that follow-up.

Keeping the smell here makes this PR's diff smaller and the refactor reviewable on its own.

Closes #66

## Test plan
- [x] Unit tests pass locally on Linux (150 passed, 14 skipped)
- [x] CI passes