### PR TITLE
refactor: replace chat completion SkippedFileErrors

### DIFF
--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -11,7 +11,7 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
 
-from .utils import SkippedFileError, parse_kwargs, read_file_with_fallback
+from .utils import EmptyFileError, parse_kwargs, read_file_with_fallback
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _IMG_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp"]
@@ -109,7 +109,7 @@ class _ChatCompletionBase:
         elif input_file.suffix.lower() in _IMG_EXTENSIONS:
             result = _ChatCompletionBase._process_img_file(context, input_file)
         else:
-            raise SkippedFileError(
+            raise ValueError(
                 f"File extension {input_file.suffix} not currently supported - "
                 "raise an issue on Github"
             )
@@ -122,7 +122,7 @@ class _ChatCompletionBase:
         content = read_file_with_fallback(input_file)
 
         if not content.strip():
-            raise SkippedFileError("Empty file")
+            raise EmptyFileError("Empty file")
 
         message = _build_txt_message(
             prompt=context.prompt,
@@ -163,7 +163,7 @@ def _run_chat(context: SetupContext, message: Any) -> str:
     except ValueError as e:
         msg = str(e).lower()
         if "max_model_len" in msg or "too long" in msg:
-            raise SkippedFileError(
+            raise ValueError(
                 f"Input exceeds max-model-len={context.max_model_len} — "
                 "increase --max-model-len or reduce the file size"
             ) from e
@@ -181,7 +181,7 @@ def _run_chat(context: SetupContext, message: Any) -> str:
             "--max-tokens and/or --max_model_len for a complete result"
         )
     elif result.finish_reason != "stop":
-        raise SkippedFileError(f"Unexpected finish reason: {result.finish_reason!r}")
+        raise RuntimeError(f"Unexpected finish reason: {result.finish_reason!r}")
 
     return result.text
 

--- a/src/tigerflow_ml/text/chat_completion/utils.py
+++ b/src/tigerflow_ml/text/chat_completion/utils.py
@@ -5,9 +5,8 @@ from pathlib import Path
 from tigerflow.logconfig import logger
 
 
-class SkippedFileError(Exception):
-    """Raised when a file should be skipped
-    (e.g., empty)."""
+class EmptyFileError(Exception):
+    """Raised when an input file is empty"""
 
     pass
 

--- a/tests/unit/text/chat_completion/test_chat_completion.py
+++ b/tests/unit/text/chat_completion/test_chat_completion.py
@@ -13,7 +13,7 @@ from tigerflow_ml.text.chat_completion._base import (
     _build_txt_message,
     _ChatCompletionBase,
 )
-from tigerflow_ml.text.chat_completion.utils import SkippedFileError
+from tigerflow_ml.text.chat_completion.utils import EmptyFileError
 
 
 def _make_context(**kwargs):
@@ -109,7 +109,7 @@ class TestRun:
         input_file = tmp_path / "file.xyz"
         input_file.write_text("content")
 
-        with pytest.raises(SkippedFileError, match="not currently supported"):
+        with pytest.raises(ValueError, match="not currently supported"):
             _ChatCompletionBase.run(context, input_file, tmp_path / "out.txt")
 
     def test_empty_text_file_raises_skipped(self, tmp_path):
@@ -117,7 +117,7 @@ class TestRun:
         input_file = tmp_path / "file.txt"
         input_file.write_text("   \n  ")
 
-        with pytest.raises(SkippedFileError, match="Empty file"):
+        with pytest.raises(EmptyFileError, match="Empty file"):
             _ChatCompletionBase.run(context, input_file, tmp_path / "out.txt")
 
     def test_whitespace_only_text_file_raises_skipped(self, tmp_path):
@@ -125,7 +125,7 @@ class TestRun:
         input_file = tmp_path / "file.txt"
         input_file.write_text("\t\n\r\n")
 
-        with pytest.raises(SkippedFileError, match="Empty file"):
+        with pytest.raises(EmptyFileError, match="Empty file"):
             _ChatCompletionBase.run(context, input_file, tmp_path / "out.txt")
 
 


### PR DESCRIPTION
Replaces `SkippedFileErrors` with `ValueErrors` and `EmptyFileErrors` in the chat completion task. A `FileNotSupportedError` could be added to `utils` if a `ValueError` is insufficient for the case when an input file has an unsupported extension. 