### PR TITLE
feat(trans): support zh-cn and zh-tw

### DIFF
--- a/src/tigerflow_ml/text/translate/detection.py
+++ b/src/tigerflow_ml/text/translate/detection.py
@@ -37,6 +37,8 @@ LANGUAGES = {
     "sv": "Swedish",
     "tr": "Turkish",
     "zh": "Chinese",
+    "zh-cn": "Simplified Chinese",
+    "zh-tw": "Traditional Chinese",
 }
 
 

--- a/tests/unit/text/translate/test_detection.py
+++ b/tests/unit/text/translate/test_detection.py
@@ -122,6 +122,6 @@ class TestLanguagesConstant:
         for code, name in LANGUAGES.items():
             assert isinstance(code, str)
             assert isinstance(name, str)
-            assert (len(code) == 2) or (
-                re.match(r"[a-z]{2}-[a-z]{2}", code)
+            assert re.fullmatch(
+                r"[a-z]{2}(-[a-z]{2})?", code
             )  # ISO 639-1 codes are 2 chars or 2-2

--- a/tests/unit/text/translate/test_detection.py
+++ b/tests/unit/text/translate/test_detection.py
@@ -120,4 +120,3 @@ class TestLanguagesConstant:
         for code, name in LANGUAGES.items():
             assert isinstance(code, str)
             assert isinstance(name, str)
-            assert len(code) == 2  # ISO 639-1 codes are 2 chars

--- a/tests/unit/text/translate/test_detection.py
+++ b/tests/unit/text/translate/test_detection.py
@@ -1,5 +1,7 @@
 """Tests for the detection module."""
 
+import re
+
 from tigerflow_ml.text.translate.detection import (
     LANGUAGES,
     _detect_sample,
@@ -120,3 +122,6 @@ class TestLanguagesConstant:
         for code, name in LANGUAGES.items():
             assert isinstance(code, str)
             assert isinstance(name, str)
+            assert (len(code) == 2) or (
+                re.match(r"[a-z]{2}-[a-z]{2}", code)
+            )  # ISO 639-1 codes are 2 chars or 2-2


### PR DESCRIPTION
Specific versions of Chinese (`zh-cn` and `zh-tw`) are supported as common languages. 