### PR TITLE
refactor: add shared helpers to utils.py

### DIFF
--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -80,6 +80,7 @@ class _DetectBase:
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
+        # TODO: use shared utils load_model_config helper
         config = AutoConfig.from_pretrained(
             context.model,
             revision=context.revision,

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -80,7 +80,6 @@ class _DetectBase:
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        # TODO: use shared utils get_model_config helper
         config = AutoConfig.from_pretrained(
             context.model,
             revision=context.revision,

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -80,7 +80,7 @@ class _DetectBase:
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        # TODO: use shared utils load_model_config helper
+        # TODO: use shared utils get_model_config helper
         config = AutoConfig.from_pretrained(
             context.model,
             revision=context.revision,

--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -10,7 +10,7 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
-from tigerflow_ml.utils import parse_kwargs, read_nonempty_text_file
+from tigerflow_ml.utils import parse_kwargs, read_text_file_strict
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _IMG_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp"]
@@ -119,7 +119,7 @@ class _ChatCompletionBase:
 
     @staticmethod
     def _process_text_file(context: SetupContext, input_file: Path) -> str:
-        content = read_nonempty_text_file(input_file)
+        content = read_text_file_strict(input_file)
 
         message = _build_txt_message(
             prompt=context.prompt,

--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -10,7 +10,7 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
-from tigerflow_ml.utils import EmptyFileError, parse_kwargs, read_file_with_fallback
+from tigerflow_ml.utils import parse_kwargs, read_nonempty_text_file
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _IMG_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp"]
@@ -119,10 +119,7 @@ class _ChatCompletionBase:
 
     @staticmethod
     def _process_text_file(context: SetupContext, input_file: Path) -> str:
-        content = read_file_with_fallback(input_file)
-
-        if not content.strip():
-            raise EmptyFileError("Empty file")
+        content = read_nonempty_text_file(input_file)
 
         message = _build_txt_message(
             prompt=context.prompt,

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -27,7 +27,7 @@ from tigerflow_ml.utils import (
     get_model_config,
     get_tokenizer,
     parse_kwargs,
-    read_nonempty_text_file,
+    read_text_file_strict,
 )
 
 from .chunking import (
@@ -154,7 +154,7 @@ class _TranslateBase:
 
         tokenizer = get_tokenizer(
             context.model,
-            fetch=context.allow_fetch,
+            allow_fetch=context.allow_fetch,
             cache_dir=context.cache_dir,
             revision=context.revision,
         )
@@ -311,7 +311,7 @@ def _translate_file(
 
     on_progress(f"Processing: {input_file.name}")
 
-    content = read_nonempty_text_file(input_file)
+    content = read_text_file_strict(input_file)
 
     on_progress(f"  File size: {len(content):,} characters")
 

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Literal
 
 import typer
 from tigerflow.logconfig import logger
@@ -24,7 +24,8 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
-    load_model_config,
+    get_model_config,
+    get_tokenizer,
     parse_kwargs,
     read_nonempty_text_file,
 )
@@ -144,14 +145,14 @@ class _TranslateBase:
                 f" --target-lang ({context.target_lang}). No translation required."
             )
 
-        config = load_model_config(
+        config = get_model_config(
             model=context.model,
             allow_fetch=context.allow_fetch,
             cache_dir=context.cache_dir,
             revision=context.revision,
         )
 
-        tokenizer = _get_tokenizer(
+        tokenizer = get_tokenizer(
             context.model,
             fetch=context.allow_fetch,
             cache_dir=context.cache_dir,
@@ -206,68 +207,6 @@ class _TranslateBase:
         )
 
         logger.info("Translation complete!")
-
-
-def _get_tokenizer(
-    model_name: str,
-    fetch: bool,
-    cache_dir: str | None = None,
-    revision: str | None = None,
-) -> PreTrainedTokenizerBase:
-    """Load tokenizer, downloading if needed and allowed."""
-    try:
-        return _load_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
-    except OSError:
-        if not fetch:
-            logger.error(f"Error: Tokenizer for '{model_name}' not found in cache.")
-            logger.error("  Run with --allow_fetch to download, or manually with:")
-            logger.error(f"    hf download {model_name} --include 'tokenizer*'")
-            raise typer.Exit(1)
-        logger.info("Downloading tokenizer from HuggingFace Hub...")
-        _download_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
-        return _load_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
-
-
-def _load_tokenizer(
-    model_name: str, cache_dir: str | None = None, revision: str | None = None
-) -> PreTrainedTokenizerBase:
-    """
-    Load a HuggingFace tokenizer from local cache
-
-    Returns:
-        Loaded tokenizer.
-
-    Raises:
-        OSError: If tokenizer not found in cache."""
-
-    from transformers import AutoTokenizer
-
-    return cast(
-        "PreTrainedTokenizerBase",
-        AutoTokenizer.from_pretrained(
-            model_name, local_files_only=True, cache_dir=cache_dir, revision=revision
-        ),
-    )
-
-
-def _download_tokenizer(
-    model_name: str, cache_dir: str | None = None, revision: str | None = None
-) -> None:
-    """
-    Download tokenizer files from HuggingFace Hub.
-
-    Args:
-        model_name: HuggingFace model name.
-        cache_dir: Optional cache directory override.
-    """
-    from huggingface_hub import snapshot_download
-
-    snapshot_download(
-        model_name,
-        allow_patterns=["tokenizer*", "special_tokens_map.json"],
-        cache_dir=cache_dir,
-        revision=revision,
-    )
 
 
 def _resolve_source_lang(

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -25,7 +25,7 @@ from tigerflow.utils import SetupContext
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
     EmptyFileError,
-    ModelConfigParsingError,
+    load_model_config,
     parse_kwargs,
     read_file_with_fallback,
 )
@@ -131,7 +131,6 @@ class _TranslateBase:
 
     @staticmethod
     def setup(context: SetupContext):
-        from transformers import AutoConfig
 
         from .translator import build_translator
 
@@ -146,15 +145,12 @@ class _TranslateBase:
                 f" --target-lang ({context.target_lang}). No translation required."
             )
 
-        try:
-            config = AutoConfig.from_pretrained(
-                context.model,
-                local_files_only=not context.allow_fetch,
-                cache_dir=context.cache_dir,
-                revision=context.revision,
-            )
-        except Exception as e:
-            raise ModelConfigParsingError(f"Failed to load model config: {e}")
+        config = load_model_config(
+            model=context.model,
+            allow_fetch=context.allow_fetch,
+            cache_dir=context.cache_dir,
+            revision=context.revision,
+        )
 
         tokenizer = _get_tokenizer(
             context.model,
@@ -225,7 +221,7 @@ def _get_tokenizer(
     except OSError:
         if not fetch:
             logger.error(f"Error: Tokenizer for '{model_name}' not found in cache.")
-            logger.error("  Run with --fetch to download, or manually with:")
+            logger.error("  Run with --allow_fetch to download, or manually with:")
             logger.error(f"    hf download {model_name} --include 'tokenizer*'")
             raise typer.Exit(1)
         logger.info("Downloading tokenizer from HuggingFace Hub...")

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -24,10 +24,9 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
-    EmptyFileError,
     load_model_config,
     parse_kwargs,
-    read_file_with_fallback,
+    read_nonempty_text_file,
 )
 
 from .chunking import (
@@ -373,10 +372,7 @@ def _translate_file(
 
     on_progress(f"Processing: {input_file.name}")
 
-    content = read_file_with_fallback(input_file)
-
-    if not content.strip():
-        raise EmptyFileError("Empty file")
+    content = read_nonempty_text_file(input_file)
 
     on_progress(f"  File size: {len(content):,} characters")
 

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -15,6 +15,8 @@ from tigerflow.logconfig import logger
 if TYPE_CHECKING:
     from transformers import PretrainedConfig, PreTrainedTokenizerBase
 
+from tigerflow_ml.utils import get_model_context_window
+
 from .chunking import DEFAULT_CHUNK_SIZE
 
 
@@ -76,17 +78,8 @@ class vllmTranslator:
         tp = torch.cuda.device_count() or 1
 
         # identify model context window to ensure max_model_len does not exceed this
-        _MAX_LEN_ATTRS = (
-            "max_position_embeddings",
-            "n_positions",
-            "n_ctx",
-            "max_seq_len",
-            "seq_length",
-        )
-        model_len_cap = next(
-            (getattr(config, a) for a in _MAX_LEN_ATTRS if hasattr(config, a)),
-            None,
-        )
+        model_len_cap = get_model_context_window(config)
+
         requested_model_len = max_model_len
         if not max_model_len:
             # max_model_len should be approx max_chunk_tokens*2 + overhead

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -32,7 +32,7 @@ class ModelConfigParsingError(Exception):
 ENCODING_FALLBACK_CHAIN = ["utf-8-sig", "cp1252", "iso-8859-15", "latin-1"]
 
 
-def read_file_with_fallback(path: Path) -> str:
+def read_text_file_with_fallback(path: Path) -> str:
     """
     Read a text file, trying multiple encodings until one succeeds.
 
@@ -64,6 +64,25 @@ def read_file_with_fallback(path: Path) -> str:
 
     # This should never be reached since latin-1 accepts all byte values
     raise RuntimeError(f"Could not decode file {path}: {last_error}")
+
+
+def read_nonempty_text_file(path: Path) -> str:
+    """
+    Read a text file, trying multiple encodings until one succeeds and raise
+    if file is empty.
+
+    Returns:
+        The file contents as a string.
+
+    Raises:
+        RuntimeError: If the file cannot be decoded with any encoding
+            (should not happen since latin-1 accepts all byte values).
+        EmptyFileError: If the file contents are empty
+    """
+    content = read_text_file_with_fallback(path)
+    if not content.strip():
+        raise EmptyFileError("Empty file")
+    return content
 
 
 def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -125,7 +125,7 @@ def load_model_config(
     except OSError as e:
         if not allow_fetch:
             raise FileNotFoundError(
-                f"Config for '{model}' not found in cache. "
+                f"Config for '{model}' not found in cache ({cache_dir}). "
                 "Run with --allow_fetch to download, or manually with: "
                 f"hf download {model}"
             ) from e
@@ -135,3 +135,35 @@ def load_model_config(
         raise ModelConfigParsingError(f"Failed to load model config: {e}") from e
 
     return config
+
+
+def get_model_context_window(config: "PretrainedConfig") -> int | None:
+    """
+    Parses a model config to identify the model's context window
+
+    Uses the attributes: max_position_embeddings, n_positions, n_ctx, max_seq_len,
+    seq_length to attempt to identify the context window.
+
+    Args:
+        config: The model's PretrainedConfig
+
+    Returns:
+        An integer representing the context window, or None if this can't be resolved
+    """
+    _MAX_LEN_ATTRS = (
+        "max_position_embeddings",
+        "n_positions",
+        "n_ctx",
+        "max_seq_len",
+        "seq_length",
+    )
+    max_model_len = next(
+        (
+            getattr(config, a)
+            for a in _MAX_LEN_ATTRS
+            if getattr(config, a, None) is not None
+        ),
+        None,
+    )
+
+    return max_model_len

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -110,7 +110,7 @@ def load_model_config(
     Raises:
         FileNotFoundError: If the config cannot be found in the cache dir and
             --allow-fetch is False
-        ConfigParsingError: If the config cannot be loaded or parsed, wrapping
+        ModelConfigParsingError: If the config cannot be loaded or parsed, wrapping
             any underlying error.
     """
     from transformers import AutoConfig

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -3,8 +3,12 @@
 import ast
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from tigerflow.logconfig import logger
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
 
 
 class EmptyFileError(Exception):
@@ -83,3 +87,51 @@ def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:
         return ast.literal_eval(value)
     except (ValueError, SyntaxError) as e:
         raise ValueError(f"--{name} is not a valid dict: {value!r}") from e
+
+
+def load_model_config(
+    model: str,
+    allow_fetch: bool = False,
+    cache_dir: str | None = None,
+    revision: str = "main",
+) -> "PretrainedConfig":
+    """
+    Load a HuggingFace model config via transformers AutoConfig.
+
+    Args:
+        model: HuggingFace model repo ID or local path.
+        allow_fetch: If False, only use locally cached files (no network access).
+        cache_dir: HuggingFace cache directory for model files.
+        revision: Model revision (branch, tag, or commit hash).
+
+    Returns:
+        The model's PretrainedConfig (architecture, vocab size, etc.).
+
+    Raises:
+        FileNotFoundError: If the config cannot be found in the cache dir and
+            --allow-fetch is False
+        ConfigParsingError: If the config cannot be loaded or parsed, wrapping
+            any underlying error.
+    """
+    from transformers import AutoConfig
+
+    try:
+        config = AutoConfig.from_pretrained(
+            model,
+            local_files_only=not allow_fetch,
+            cache_dir=cache_dir,
+            revision=revision,
+        )
+    except OSError as e:
+        if not allow_fetch:
+            raise FileNotFoundError(
+                f"Config for '{model}' not found in cache. "
+                "Run with --allow_fetch to download, or manually with: "
+                f"hf download {model}"
+            ) from e
+
+        raise ModelConfigParsingError(f"Failed to load model config: {e}") from e
+    except Exception as e:
+        raise ModelConfigParsingError(f"Failed to load model config: {e}") from e
+
+    return config

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -66,10 +66,10 @@ def read_text_file_with_fallback(path: Path) -> str:
     raise RuntimeError(f"Could not decode file {path}: {last_error}")
 
 
-def read_nonempty_text_file(path: Path) -> str:
+def read_text_file_strict(path: Path) -> str:
     """
-    Read a text file, trying multiple encodings until one succeeds and raise
-    if file is empty.
+    Read a text file, trying multiple encodings until one succeeds, and raise
+    if file is empty or contains only white space.
 
     Args:
         path: Path to the file to read.
@@ -80,11 +80,12 @@ def read_nonempty_text_file(path: Path) -> str:
     Raises:
         RuntimeError: If the file cannot be decoded with any encoding
             (should not happen since latin-1 accepts all byte values).
-        EmptyFileError: If the file contents are empty
+        EmptyFileError: If the file contents are empty or contain only
+            white space
     """
     content = read_text_file_with_fallback(path)
     if not content.strip():
-        raise EmptyFileError("Empty file")
+        raise EmptyFileError(f"File is empty: {path}")
     return content
 
 
@@ -161,7 +162,7 @@ def get_model_config(
 
 def get_tokenizer(
     model_name: str,
-    fetch: bool,
+    allow_fetch: bool,
     cache_dir: str | None = None,
     revision: str | None = None,
 ) -> "PreTrainedTokenizerBase":
@@ -169,7 +170,7 @@ def get_tokenizer(
     try:
         return _load_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
     except OSError:
-        if not fetch:
+        if not allow_fetch:
             raise RuntimeError(
                 f"Tokenizer for '{model_name}' not found in cache ({cache_dir}). "
                 "Run with --allow_fetch to download, or manually with: "

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -3,16 +3,16 @@
 import ast
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from tigerflow.logconfig import logger
 
 if TYPE_CHECKING:
-    from transformers import PretrainedConfig
+    from transformers import PretrainedConfig, PreTrainedTokenizerBase
 
 
 class EmptyFileError(Exception):
-    """Raised when a input file is empty"""
+    """Raised when an input file is empty"""
 
     pass
 
@@ -71,6 +71,9 @@ def read_nonempty_text_file(path: Path) -> str:
     Read a text file, trying multiple encodings until one succeeds and raise
     if file is empty.
 
+    Args:
+        path: Path to the file to read.
+
     Returns:
         The file contents as a string.
 
@@ -108,7 +111,7 @@ def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:
         raise ValueError(f"--{name} is not a valid dict: {value!r}") from e
 
 
-def load_model_config(
+def get_model_config(
     model: str,
     allow_fetch: bool = False,
     cache_dir: str | None = None,
@@ -154,6 +157,69 @@ def load_model_config(
         raise ModelConfigParsingError(f"Failed to load model config: {e}") from e
 
     return config
+
+
+def get_tokenizer(
+    model_name: str,
+    fetch: bool,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+) -> "PreTrainedTokenizerBase":
+    """Load tokenizer, downloading if needed and allowed."""
+    try:
+        return _load_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
+    except OSError:
+        if not fetch:
+            raise RuntimeError(
+                f"Tokenizer for '{model_name}' not found in cache ({cache_dir}). "
+                "Run with --allow_fetch to download, or manually with: "
+                f"hf download {model_name} --include 'tokenizer*'"
+            )
+        logger.info("Downloading tokenizer from HuggingFace Hub...")
+        _download_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
+        return _load_tokenizer(model_name, cache_dir=cache_dir, revision=revision)
+
+
+def _load_tokenizer(
+    model_name: str, cache_dir: str | None = None, revision: str | None = None
+) -> "PreTrainedTokenizerBase":
+    """
+    Load a HuggingFace tokenizer from local cache
+
+    Returns:
+        Loaded tokenizer.
+
+    Raises:
+        OSError: If tokenizer not found in cache."""
+
+    from transformers import AutoTokenizer
+
+    return cast(
+        "PreTrainedTokenizerBase",
+        AutoTokenizer.from_pretrained(
+            model_name, local_files_only=True, cache_dir=cache_dir, revision=revision
+        ),
+    )
+
+
+def _download_tokenizer(
+    model_name: str, cache_dir: str | None = None, revision: str | None = None
+) -> None:
+    """
+    Download tokenizer files from HuggingFace Hub.
+
+    Args:
+        model_name: HuggingFace model name.
+        cache_dir: Optional cache directory override.
+    """
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(
+        model_name,
+        allow_patterns=["tokenizer*", "special_tokens_map.json"],
+        cache_dir=cache_dir,
+        revision=revision,
+    )
 
 
 def get_model_context_window(config: "PretrainedConfig") -> int | None:

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -2,6 +2,7 @@
 
 from tigerflow_ml.audio.transcribe._base import _TranscribeBase
 from tigerflow_ml.image.detect._base import _DetectBase
+from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.text.ocr._base import _OCRBase
 
 
@@ -32,3 +33,18 @@ def test_detect_defaults():
     assert p.batch_size == 4
     assert p.sample_fps == 1.0
     assert p.labels == ""
+
+
+def test_vLLM_defaults():
+    p = VLLMParams()
+    assert p.revision == "main"
+    assert p.cache_dir is None
+    assert p.allow_fetch is False
+    assert p.system_message is None
+    assert p.max_tokens == 512
+    assert p.max_model_len is None
+    assert p.temperature == 0
+    assert p.seed == 42
+    assert p.llm_kwargs == "{}"
+    assert p.sampling_kwargs == "{}"
+    assert p.chat_kwargs == "{}"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 
 from tigerflow_ml.utils import (
     ENCODING_FALLBACK_CHAIN,
-    ConfigParsingError,
+    ModelConfigParsingError,
     load_model_config,
     read_file_with_fallback,
 )
@@ -113,7 +113,7 @@ class TestLoadModelConfig:
             "transformers.AutoConfig.from_pretrained",
             side_effect=OSError("network error"),
         ):
-            with pytest.raises(ConfigParsingError):
+            with pytest.raises(ModelConfigParsingError):
                 load_model_config("some/model", allow_fetch=True)
 
     def test_unexpected_exception_raises_config_parsing_error(self):
@@ -121,5 +121,5 @@ class TestLoadModelConfig:
             "transformers.AutoConfig.from_pretrained",
             side_effect=ValueError("bad config"),
         ):
-            with pytest.raises(ConfigParsingError, match="bad config"):
+            with pytest.raises(ModelConfigParsingError, match="bad config"):
                 load_model_config("some/model")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,10 +7,12 @@ import pytest
 
 from tigerflow_ml.utils import (
     ENCODING_FALLBACK_CHAIN,
+    EmptyFileError,
     ModelConfigParsingError,
     get_model_context_window,
     load_model_config,
-    read_file_with_fallback,
+    read_nonempty_text_file,
+    read_text_file_with_fallback,
 )
 
 
@@ -33,7 +35,7 @@ class TestReadFileWithFallback:
         content = "Hello, world! Привет мир! 你好世界!"
         file_path.write_text(content, encoding="utf-8")
 
-        result = read_file_with_fallback(file_path)
+        result = read_text_file_with_fallback(file_path)
         assert result == content
 
     def test_reads_utf8_bom_file(self, tmp_path):
@@ -41,7 +43,7 @@ class TestReadFileWithFallback:
         content = "Hello with BOM"
         file_path.write_bytes(b"\xef\xbb\xbf" + content.encode("utf-8"))
 
-        result = read_file_with_fallback(file_path)
+        result = read_text_file_with_fallback(file_path)
         assert result == content
 
     def test_reads_cp1252_file(self, tmp_path):
@@ -50,7 +52,7 @@ class TestReadFileWithFallback:
         content = "Hello \u201cworld\u201d \u2014 test"
         file_path.write_bytes(content.encode("cp1252"))
 
-        result = read_file_with_fallback(file_path)
+        result = read_text_file_with_fallback(file_path)
         assert "Hello" in result
         assert "test" in result
 
@@ -59,28 +61,51 @@ class TestReadFileWithFallback:
         content = "Café résumé naïve"
         file_path.write_bytes(content.encode("latin-1"))
 
-        result = read_file_with_fallback(file_path)
+        result = read_text_file_with_fallback(file_path)
         # Should successfully read (though may decode differently)
         assert len(result) > 0
 
     def test_nonexistent_file_raises(self, tmp_path):
         file_path = tmp_path / "nonexistent.txt"
         with pytest.raises(FileNotFoundError):
-            read_file_with_fallback(file_path)
+            read_text_file_with_fallback(file_path)
 
     def test_empty_file_returns_empty_string(self, tmp_path):
         file_path = tmp_path / "empty.txt"
         file_path.write_text("")
 
-        result = read_file_with_fallback(file_path)
+        result = read_text_file_with_fallback(file_path)
         assert result == ""
 
     def test_file_with_only_whitespace(self, tmp_path):
         file_path = tmp_path / "whitespace.txt"
         file_path.write_text("   \n\n   \t\t   ")
 
-        result = read_file_with_fallback(file_path)
+        result = read_text_file_with_fallback(file_path)
         assert result == "   \n\n   \t\t   "
+
+
+class TestReadNonemptyTextFile:
+    def test_returns_content_for_normal_file(self, tmp_path):
+        file_path = tmp_path / "test.txt"
+        file_path.write_text("Hello, world!")
+        assert read_nonempty_text_file(file_path) == "Hello, world!"
+
+    def test_empty_file_raises(self, tmp_path):
+        file_path = tmp_path / "empty.txt"
+        file_path.write_text("")
+        with pytest.raises(EmptyFileError):
+            read_nonempty_text_file(file_path)
+
+    def test_whitespace_only_raises(self, tmp_path):
+        file_path = tmp_path / "whitespace.txt"
+        file_path.write_text("   \n\n\t  ")
+        with pytest.raises(EmptyFileError):
+            read_nonempty_text_file(file_path)
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_nonempty_text_file(tmp_path / "nonexistent.txt")
 
 
 class TestLoadModelConfig:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,8 +9,9 @@ from tigerflow_ml.utils import (
     ENCODING_FALLBACK_CHAIN,
     EmptyFileError,
     ModelConfigParsingError,
+    get_model_config,
     get_model_context_window,
-    load_model_config,
+    get_tokenizer,
     read_nonempty_text_file,
     read_text_file_with_fallback,
 )
@@ -108,11 +109,11 @@ class TestReadNonemptyTextFile:
             read_nonempty_text_file(tmp_path / "nonexistent.txt")
 
 
-class TestLoadModelConfig:
+class TestGetModelConfig:
     def test_returns_config_on_success(self):
         mock_config = MagicMock()
         with patch("transformers.AutoConfig.from_pretrained", return_value=mock_config):
-            result = load_model_config("some/model")
+            result = get_model_config("some/model")
         assert result is mock_config
 
     def test_passes_args_to_from_pretrained(self):
@@ -120,7 +121,7 @@ class TestLoadModelConfig:
         with patch(
             "transformers.AutoConfig.from_pretrained", return_value=mock_config
         ) as mock_fn:
-            load_model_config(
+            get_model_config(
                 "some/model", allow_fetch=True, cache_dir="/cache", revision="v1"
             )
         mock_fn.assert_called_once_with(
@@ -133,7 +134,7 @@ class TestLoadModelConfig:
     def test_oserror_no_fetch_raises_file_not_found(self):
         with patch("transformers.AutoConfig.from_pretrained", side_effect=OSError):
             with pytest.raises(FileNotFoundError, match="some/model"):
-                load_model_config("some/model", allow_fetch=False)
+                get_model_config("some/model", allow_fetch=False)
 
     def test_oserror_allow_fetch_raises_config_parsing_error(self):
         with patch(
@@ -141,7 +142,7 @@ class TestLoadModelConfig:
             side_effect=OSError("network error"),
         ):
             with pytest.raises(ModelConfigParsingError):
-                load_model_config("some/model", allow_fetch=True)
+                get_model_config("some/model", allow_fetch=True)
 
     def test_unexpected_exception_raises_config_parsing_error(self):
         with patch(
@@ -149,7 +150,46 @@ class TestLoadModelConfig:
             side_effect=ValueError("bad config"),
         ):
             with pytest.raises(ModelConfigParsingError, match="bad config"):
-                load_model_config("some/model")
+                get_model_config("some/model")
+
+
+class TestGetTokenizer:
+    def test_returns_tokenizer_on_success(self):
+        mock_tokenizer = MagicMock()
+        with patch("tigerflow_ml.utils._load_tokenizer", return_value=mock_tokenizer):
+            result = get_tokenizer("some/model", fetch=False)
+        assert result is mock_tokenizer
+
+    def test_passes_args_to_load_tokenizer(self):
+        mock_tokenizer = MagicMock()
+        with patch(
+            "tigerflow_ml.utils._load_tokenizer", return_value=mock_tokenizer
+        ) as mock_fn:
+            get_tokenizer("some/model", fetch=False, cache_dir="/cache", revision="v1")
+        mock_fn.assert_called_once_with("some/model", cache_dir="/cache", revision="v1")
+
+    def test_oserror_no_fetch_raises_runtime_error(self):
+        with patch("tigerflow_ml.utils._load_tokenizer", side_effect=OSError):
+            with pytest.raises(RuntimeError, match="some/model"):
+                get_tokenizer("some/model", fetch=False)
+
+    def test_fetch_downloads_then_loads_tokenizer(self):
+        mock_tokenizer = MagicMock()
+        # First call raises OSError (cache miss), second succeeds after download
+        with (
+            patch(
+                "tigerflow_ml.utils._load_tokenizer",
+                side_effect=[OSError, mock_tokenizer],
+            ) as mock_load,
+            patch("tigerflow_ml.utils._download_tokenizer") as mock_download,
+        ):
+            result = get_tokenizer("some/model", fetch=True, cache_dir="/cache")
+
+        assert result is mock_tokenizer
+        mock_download.assert_called_once_with(
+            "some/model", cache_dir="/cache", revision=None
+        )
+        assert mock_load.call_count == 2
 
 
 class TestGetModelContextWindow:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,7 +12,7 @@ from tigerflow_ml.utils import (
     get_model_config,
     get_model_context_window,
     get_tokenizer,
-    read_nonempty_text_file,
+    read_text_file_strict,
     read_text_file_with_fallback,
 )
 
@@ -90,23 +90,23 @@ class TestReadNonemptyTextFile:
     def test_returns_content_for_normal_file(self, tmp_path):
         file_path = tmp_path / "test.txt"
         file_path.write_text("Hello, world!")
-        assert read_nonempty_text_file(file_path) == "Hello, world!"
+        assert read_text_file_strict(file_path) == "Hello, world!"
 
     def test_empty_file_raises(self, tmp_path):
         file_path = tmp_path / "empty.txt"
         file_path.write_text("")
         with pytest.raises(EmptyFileError):
-            read_nonempty_text_file(file_path)
+            read_text_file_strict(file_path)
 
     def test_whitespace_only_raises(self, tmp_path):
         file_path = tmp_path / "whitespace.txt"
         file_path.write_text("   \n\n\t  ")
         with pytest.raises(EmptyFileError):
-            read_nonempty_text_file(file_path)
+            read_text_file_strict(file_path)
 
     def test_nonexistent_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
-            read_nonempty_text_file(tmp_path / "nonexistent.txt")
+            read_text_file_strict(tmp_path / "nonexistent.txt")
 
 
 class TestGetModelConfig:
@@ -157,7 +157,7 @@ class TestGetTokenizer:
     def test_returns_tokenizer_on_success(self):
         mock_tokenizer = MagicMock()
         with patch("tigerflow_ml.utils._load_tokenizer", return_value=mock_tokenizer):
-            result = get_tokenizer("some/model", fetch=False)
+            result = get_tokenizer("some/model", allow_fetch=False)
         assert result is mock_tokenizer
 
     def test_passes_args_to_load_tokenizer(self):
@@ -165,13 +165,15 @@ class TestGetTokenizer:
         with patch(
             "tigerflow_ml.utils._load_tokenizer", return_value=mock_tokenizer
         ) as mock_fn:
-            get_tokenizer("some/model", fetch=False, cache_dir="/cache", revision="v1")
+            get_tokenizer(
+                "some/model", allow_fetch=False, cache_dir="/cache", revision="v1"
+            )
         mock_fn.assert_called_once_with("some/model", cache_dir="/cache", revision="v1")
 
     def test_oserror_no_fetch_raises_runtime_error(self):
         with patch("tigerflow_ml.utils._load_tokenizer", side_effect=OSError):
             with pytest.raises(RuntimeError, match="some/model"):
-                get_tokenizer("some/model", fetch=False)
+                get_tokenizer("some/model", allow_fetch=False)
 
     def test_fetch_downloads_then_loads_tokenizer(self):
         mock_tokenizer = MagicMock()
@@ -183,7 +185,7 @@ class TestGetTokenizer:
             ) as mock_load,
             patch("tigerflow_ml.utils._download_tokenizer") as mock_download,
         ):
-            result = get_tokenizer("some/model", fetch=True, cache_dir="/cache")
+            result = get_tokenizer("some/model", allow_fetch=True, cache_dir="/cache")
 
         assert result is mock_tokenizer
         mock_download.assert_called_once_with(
@@ -211,6 +213,8 @@ class TestGetModelContextWindow:
             max_position_embeddings=4096,
             n_positions=2048,
             n_ctx=1024,
+            max_seq_len=512,
+            seq_length=256,
         )
         assert get_model_context_window(config) == 4096
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 """Tests for the shared utils module."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from tigerflow_ml.utils import (
     ENCODING_FALLBACK_CHAIN,
     ModelConfigParsingError,
+    get_model_context_window,
     load_model_config,
     read_file_with_fallback,
 )
@@ -123,3 +125,34 @@ class TestLoadModelConfig:
         ):
             with pytest.raises(ModelConfigParsingError, match="bad config"):
                 load_model_config("some/model")
+
+
+class TestGetModelContextWindow:
+    def test_returns_all_max_len_attributes(self):
+        _MAX_LEN_ATTRS = (
+            "max_position_embeddings",
+            "n_positions",
+            "n_ctx",
+            "max_seq_len",
+            "seq_length",
+        )
+        for attr in _MAX_LEN_ATTRS:
+            config = SimpleNamespace(**{attr: 4096})
+            assert get_model_context_window(config) == 4096
+
+    def test_priority_order(self):
+        # max_position_embeddings takes precedence over all others
+        config = SimpleNamespace(
+            max_position_embeddings=4096,
+            n_positions=2048,
+            n_ctx=1024,
+        )
+        assert get_model_context_window(config) == 4096
+
+    def test_skips_none_valued_attribute(self):
+        config = SimpleNamespace(max_position_embeddings=None, n_positions=2048)
+        assert get_model_context_window(config) == 2048
+
+    def test_returns_none_when_no_known_attrs(self):
+        config = SimpleNamespace(hidden_size=768, num_layers=12)
+        assert get_model_context_window(config) is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,9 +1,13 @@
 """Tests for the shared utils module."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from tigerflow_ml.utils import (
     ENCODING_FALLBACK_CHAIN,
+    ConfigParsingError,
+    load_model_config,
     read_file_with_fallback,
 )
 
@@ -75,3 +79,47 @@ class TestReadFileWithFallback:
 
         result = read_file_with_fallback(file_path)
         assert result == "   \n\n   \t\t   "
+
+
+class TestLoadModelConfig:
+    def test_returns_config_on_success(self):
+        mock_config = MagicMock()
+        with patch("transformers.AutoConfig.from_pretrained", return_value=mock_config):
+            result = load_model_config("some/model")
+        assert result is mock_config
+
+    def test_passes_args_to_from_pretrained(self):
+        mock_config = MagicMock()
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_config
+        ) as mock_fn:
+            load_model_config(
+                "some/model", allow_fetch=True, cache_dir="/cache", revision="v1"
+            )
+        mock_fn.assert_called_once_with(
+            "some/model",
+            local_files_only=False,
+            cache_dir="/cache",
+            revision="v1",
+        )
+
+    def test_oserror_no_fetch_raises_file_not_found(self):
+        with patch("transformers.AutoConfig.from_pretrained", side_effect=OSError):
+            with pytest.raises(FileNotFoundError, match="some/model"):
+                load_model_config("some/model", allow_fetch=False)
+
+    def test_oserror_allow_fetch_raises_config_parsing_error(self):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=OSError("network error"),
+        ):
+            with pytest.raises(ConfigParsingError):
+                load_model_config("some/model", allow_fetch=True)
+
+    def test_unexpected_exception_raises_config_parsing_error(self):
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=ValueError("bad config"),
+        ):
+            with pytest.raises(ConfigParsingError, match="bad config"):
+                load_model_config("some/model")

--- a/tests/unit/text/chat_completion/test_chat_completion.py
+++ b/tests/unit/text/chat_completion/test_chat_completion.py
@@ -117,7 +117,7 @@ class TestRun:
         input_file = tmp_path / "file.txt"
         input_file.write_text("   \n  ")
 
-        with pytest.raises(EmptyFileError, match="Empty file"):
+        with pytest.raises(EmptyFileError, match="File is empty"):
             _ChatCompletionBase.run(context, input_file, tmp_path / "out.txt")
 
     def test_whitespace_only_text_file_raises_skipped(self, tmp_path):
@@ -125,7 +125,7 @@ class TestRun:
         input_file = tmp_path / "file.txt"
         input_file.write_text("\t\n\r\n")
 
-        with pytest.raises(EmptyFileError, match="Empty file"):
+        with pytest.raises(EmptyFileError, match="File is empty"):
             _ChatCompletionBase.run(context, input_file, tmp_path / "out.txt")
 
 


### PR DESCRIPTION
Adds the following helpers to the shared utils file: 
- read_text_file_strict()
- get_model_config()
- get_tokenizer()
- get_model_context_window()

Closes #46 