### PR TITLE
build: move vllm to optional extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install dependencies
-        run: uv sync --locked --group lint
+        run: uv sync --locked --group lint --no-extra vllm
 
       - name: Run pre-commit
         run: uv run pre-commit run --all-files
@@ -84,7 +84,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --locked --group test
+        run: uv sync --locked --group test --no-extra vllm
 
       - name: Run tests
         run: uv run pytest tests

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -39,6 +39,7 @@ hide:
 - [Translation](tasks/translate.md) — Translate text documents
 - [Transcription](tasks/transcribe.md) — Transcribe audio to text
 - [Object Detection](tasks/detect.md) — Detect objects in images and videos
+- [Chat Completion](tasks/chat_completion.md) - Apply a chat prompt to text or image documents
 
 ## Installation
 
@@ -46,6 +47,12 @@ TigerFlow ML requires [TigerFlow](https://github.com/princeton-ddss/tigerflow) t
 
 ```bash
 pip install tigerflow tigerflow-ml
+```
+
+If using a task that relies on `vllm` (chat completion or translation), install with:
+
+```bash
+pip install tigerflow-ml[vllm]
 ```
 
 ## Next Steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ dependencies = [
     "langdetect>=1.0.9",
     "protobuf",
     "accelerate>=1.13.0",
-    "vllm>=0.19.1",
 ]
+
+[project.optional-dependencies]
+vllm = [ "vllm>=0.19.1"]
 
 [project.urls]
 Repository = "https://github.com/princeton-ddss/tigerflow-ml"

--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -41,7 +41,6 @@ class _ChatCompletionBase:
     def setup(context: SetupContext):
         import torch
         from huggingface_hub import snapshot_download
-        from vllm import LLM, SamplingParams
 
         if context.max_model_len and context.max_tokens >= context.max_model_len:
             raise ValueError(
@@ -68,6 +67,8 @@ class _ChatCompletionBase:
                 logger.error(f"    hf download {context.model}")
                 raise typer.Exit(1)
             raise RuntimeError(f"Failed to download '{context.model}': {e}") from e
+
+        from vllm import LLM, SamplingParams
 
         tp = torch.cuda.device_count() or 1
 

--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -68,7 +68,7 @@ class _ChatCompletionBase:
                 raise typer.Exit(1)
             raise RuntimeError(f"Failed to download '{context.model}': {e}") from e
 
-        from vllm import LLM, SamplingParams
+        from vllm import LLM, SamplingParams  # type: ignore[import-unresolved]
 
         tp = torch.cuda.device_count() or 1
 

--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -68,7 +68,7 @@ class _ChatCompletionBase:
                 raise typer.Exit(1)
             raise RuntimeError(f"Failed to download '{context.model}': {e}") from e
 
-        from vllm import LLM, SamplingParams  # type: ignore[import-unresolved]
+        from vllm import LLM, SamplingParams  # type: ignore
 
         tp = torch.cuda.device_count() or 1
 

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -57,7 +57,7 @@ class vllmTranslator:
     ):
         import torch
         from huggingface_hub import snapshot_download
-        from vllm import LLM, SamplingParams
+        from vllm import LLM, SamplingParams  # type: ignore[import-unresolved]
 
         user_llm_kwargs = user_llm_kwargs or {}
         user_sampling_kwargs = user_sampling_kwargs or {}

--- a/src/tigerflow_ml/text/translate/translator.py
+++ b/src/tigerflow_ml/text/translate/translator.py
@@ -57,7 +57,7 @@ class vllmTranslator:
     ):
         import torch
         from huggingface_hub import snapshot_download
-        from vllm import LLM, SamplingParams  # type: ignore[import-unresolved]
+        from vllm import LLM, SamplingParams  # type: ignore
 
         user_llm_kwargs = user_llm_kwargs or {}
         user_sampling_kwargs = user_sampling_kwargs or {}

--- a/uv.lock
+++ b/uv.lock
@@ -1104,10 +1104,18 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/33/c97b2bcbe06e0f011eedee0f41d4060f6344901a53c2703acc3dd7429713/fastsafetensors-0.3.2.tar.gz", hash = "sha256:9e358fce238684613a5c3ebb7800c52c5b3270c0bb5e4ed2191ee8f3d0431de1", size = 70409, upload-time = "2026-05-22T05:39:34.787Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/69/12598d840d364ed9601e2e54462c6bd0b582651c0e42d789e6b498015901/fastsafetensors-0.3.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e34eb6ce278cdf35a677fedf235809a93dca255e13b88a96f9c4dd49c0fcbd13", size = 1830138, upload-time = "2026-06-04T09:02:50.663Z" },
     { url = "https://files.pythonhosted.org/packages/66/87/590d52e847f1e7a71a92398274504604c462ec67c4d8286e79a0dbca4cb1/fastsafetensors-0.3.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ff3f8cbc2ad0f8730728bec8aeb43b7bcbff1dae37ede2ea0a946062a8da62b", size = 1861977, upload-time = "2026-05-22T05:39:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/32/56/04b80105e7286f53361dfc347a180a96a3960fa47240107fc2acd4ab34b0/fastsafetensors-0.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:1ea80402c203a55dccbcf5f0f5aa7c3b6a432a7dda8f4663dd7c8418e4257877", size = 199901, upload-time = "2026-06-04T09:02:52.19Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0c/648d52f31c351efbdd9b222fd80e2b4ed8e11d3f68ea3b65af628dbe480a/fastsafetensors-0.3.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:912b8b1ef169e39c1daf2477a3f4f10a1953a50444c0f93264321a87a5b42cf2", size = 1848120, upload-time = "2026-06-04T09:02:53.419Z" },
     { url = "https://files.pythonhosted.org/packages/23/8f/ade9adae5853eb7bb674bfd97f340ab7bfea7afaade508fd791ffb06c3b7/fastsafetensors-0.3.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b8780ff0291ff4c9a440c7b25cb8a8b963d8600ab86b89b2a8aebea26d58366", size = 1881819, upload-time = "2026-05-22T05:39:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6a/c74d5c83cf03226332767fd35fc11d20f2b1e4fc28eb742b029f06f571ff/fastsafetensors-0.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:c2059829de1762a7607ce707c17267c81cc1713fbe72dafc3b7ba55fc2632f73", size = 200813, upload-time = "2026-06-04T09:02:54.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bb/9f821eac9bddd41ea1c5cd9b6a597c002741f022ecf6f3ba5cfcc3e9c950/fastsafetensors-0.3.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f4d8cbd3b542e5ddf7fee8136cf35e1524f9c30e118f64a0e846dab7e8de6b", size = 1877989, upload-time = "2026-06-04T09:02:56.11Z" },
     { url = "https://files.pythonhosted.org/packages/e9/68/a31c1661adf4d1b5ec29470ff991bde9094e4f347b0e6d1af8ba6b560d32/fastsafetensors-0.3.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6a932d7166c9e17e48aca3e5503d326bc6fc73fce6dc985ae6bd2ccc0f308b14", size = 1907188, upload-time = "2026-05-22T05:39:30.242Z" },
+    { url = "https://files.pythonhosted.org/packages/45/d3/8c05a01aa9518c5118d133a6554334f642ef08f050d0b94f7daac539d265/fastsafetensors-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:b02dd7a2332013c24cce1fb9cd037326c6b52dd25e84fa07d02d61c6301b54e8", size = 201967, upload-time = "2026-06-04T09:02:57.412Z" },
+    { url = "https://files.pythonhosted.org/packages/37/39/9e5ba486b82f547bec40543e10077e44b3eca4d92da381bcb0780b1169fd/fastsafetensors-0.3.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93cd3fd6f3c66334edbfc64f3e2457f4b622c38c16074616a0dc2d972b0a65b7", size = 1877661, upload-time = "2026-06-04T09:02:58.577Z" },
     { url = "https://files.pythonhosted.org/packages/e4/43/57fd9ee68a39f1a5fba0dd9be6b62f14460bab532840eb8198202fd73d30/fastsafetensors-0.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41297f01d3e2585e86fbc56df499f140b233ec8d6cb17c3f95b5e81a8b98a53e", size = 1906826, upload-time = "2026-05-22T05:39:31.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9e/666806437c65acec5471d73af36a8cf5875db762dd9e4197531c6ad8e7c4/fastsafetensors-0.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:19459e96f4e732ae8470a44362bd30d00da20a76c61cd75e894855d4d0739205", size = 202019, upload-time = "2026-06-04T09:02:59.921Z" },
 ]
 
 [[package]]
@@ -4638,6 +4646,10 @@ dependencies = [
     { name = "timm" },
     { name = "torch" },
     { name = "transformers" },
+]
+
+[package.optional-dependencies]
+vllm = [
     { name = "vllm" },
 ]
 
@@ -4676,8 +4688,9 @@ requires-dist = [
     { name = "timm" },
     { name = "torch", specifier = ">=2.0" },
     { name = "transformers", specifier = ">=4.51" },
-    { name = "vllm", specifier = ">=0.19.1" },
+    { name = "vllm", marker = "extra == 'vllm'", specifier = ">=0.19.1" },
 ]
+provides-extras = ["vllm"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Moves vllm out of [project.dependencies] and into an optional extra to allow unit-test development on Mac. 

- Moves vllm>=0.19.1 from [project.dependencies] to [project.optional-dependencies] as a vllm extra
- Updates install docs to recommend pip install tigerflow-ml[vllm] for use of translate/chat_completion
- `uv.lock` updated
- CI tests updated to run explicitly without vllm (import needs to have `# type: ignore` to avoid linting error)

I didn't remove `tool.uv.no-build-package = ["vllm"]` since this still prevents accidental installation of version 20 on linux