### PR TITLE
feat: add allow-fetch to HFParams + seed and temp to OCR

### DIFF
--- a/docs/mkdocs/tasks/detect.md
+++ b/docs/mkdocs/tasks/detect.md
@@ -9,7 +9,7 @@ Supports both fixed-class models (e.g. RT-DETR) and open-vocabulary models
 
 | Parameter      | Default                | Description                                                            |
 |----------------|------------------------|------------------------------------------------------------------------|
-| `--model`      | `PekingU/rtdetr_r50vd` | HuggingFace model repo ID                                             |
+| `--model`      | `PekingU/rtdetr_r50vd` | HuggingFace model repo ID                                              |
 | `--revision`   | `main`                 | Model revision (branch, tag, or commit hash)                           |
 | `--cache-dir`  |                        | HuggingFace cache directory for model files                            |
 | `--device`     | `auto`                 | Device to use (`cuda`, `cpu`, or `auto`)                               |
@@ -17,6 +17,8 @@ Supports both fixed-class models (e.g. RT-DETR) and open-vocabulary models
 | `--threshold`  | `0.3`                  | Minimum confidence score for detections                                |
 | `--batch-size` | `4`                    | Number of video frames to process in parallel on GPU                   |
 | `--sample-fps` | `1.0`                  | Frames per second to sample from video (0 = every frame)               |
+| `--allow-fetch` | `--no-allow-fetch`    | Allow downloads from HuggingFace Hub (network access required)         |
+
 
 ## Supported Input Formats
 

--- a/docs/mkdocs/tasks/detect.md
+++ b/docs/mkdocs/tasks/detect.md
@@ -95,6 +95,8 @@ Uses the default RT-DETR model which recognizes 80 common object categories (COC
         module: tigerflow_ml.image.detect.local
         input_ext: .jpg
         output_ext: .json
+        params:
+          allow-fetch: True
     ```
 
 === "Input"
@@ -137,6 +139,7 @@ Use an open-vocabulary model to detect arbitrary objects described by text label
           model: IDEA-Research/grounding-dino-base
           labels: "solar panel,wind turbine,power line"
           threshold: 0.2
+          allow-fetch: True
     ```
 
 === "Input"
@@ -177,6 +180,7 @@ runs detection on each frame.
         params:
           sample_fps: 2.0
           batch_size: 8
+          allow-fetch: True
     ```
 
 === "Input"
@@ -230,4 +234,5 @@ tasks:
     params:
       sample_fps: 1.0
       batch_size: 8
+      cache_dir: ~/path/to/model/hub
 ```

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -61,6 +61,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         input_ext: .jpg
         output_ext: .txt  # or .md, .json
         params:
+          allow-fetch: True #if model is not already downloaded
           # output_format: text       # (default) plain text
           # output_format: markdown   # formatted markdown/LaTeX
           # output_format: json       # structured JSON with pages
@@ -125,6 +126,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         output_ext: .md
         params:
           output_format: markdown
+          allow_fetch: True
     ```
 
 === "Input"
@@ -199,6 +201,8 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         module: tigerflow_ml.text.ocr.local
         input_ext: .pdf
         output_ext: .txt
+        params:
+          allow_fetch: True
     ```
 
 === "Input"
@@ -262,4 +266,6 @@ tasks:
       gpus: 1
       memory: 16G
       time: 04:00:00
+    params:
+      cache_dir: ~/path/to/model/hub/
 ```

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -12,8 +12,11 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 | `--device`        | `auto`                        | Device to use (`cuda`, `cpu`, or `auto`)       |
 | `--output-format` | `text`                        | Output format: `text`, `markdown`, or `json`   |
 | `--max-length`    | `4096`                        | Maximum number of tokens to generate per image |
-| `--batch-size`    | `4`                           | Number of images to process in parallel on GPU |
 | `--prompt`        | `Extract all text from this image.` | Prompt for image-text-to-text models     |
+| `--temperature`   | `0.0`                         | Sampling temperature. Lower values make output more deterministic. |
+| `--seed`          | `42`                          | Random seed for reproducibility |
+| `--allow-fetch`   | `--no-allow-fetch`            | Allow downloads from HuggingFace Hub (network access required) |
+
 
 ## Supported Input Formats
 

--- a/docs/mkdocs/tasks/transcribe.md
+++ b/docs/mkdocs/tasks/transcribe.md
@@ -16,6 +16,9 @@ Transcribe audio to text using HuggingFace Whisper models.
 | `--chunk-length-s`    | `30.0`                    | Length of audio chunks in seconds                             |
 | `--stride-length-s`   | `5.0`                     | Overlap between chunks in seconds                             |
 | `--return-timestamps` | `false`                   | Return word/segment timestamps (required for SRT)             |
+| `--temperature`       | `0.0`                     | Sampling temperature. Lower values make output more deterministic. |
+| `--seed`              | `42`                      | Random seed for reproducibility                                |
+| `--allow-fetch`       | `--no-allow-fetch`        | Allow downloads from HuggingFace Hub (network access required) |
 
 ## Supported Input Formats
 

--- a/docs/mkdocs/tasks/transcribe.md
+++ b/docs/mkdocs/tasks/transcribe.md
@@ -16,8 +16,6 @@ Transcribe audio to text using HuggingFace Whisper models.
 | `--chunk-length-s`    | `30.0`                    | Length of audio chunks in seconds                             |
 | `--stride-length-s`   | `5.0`                     | Overlap between chunks in seconds                             |
 | `--return-timestamps` | `false`                   | Return word/segment timestamps (required for SRT)             |
-| `--temperature`       | `0.0`                     | Sampling temperature. Lower values make output more deterministic. |
-| `--seed`              | `42`                      | Random seed for reproducibility                                |
 | `--allow-fetch`       | `--no-allow-fetch`        | Allow downloads from HuggingFace Hub (network access required) |
 
 ## Supported Input Formats

--- a/docs/mkdocs/tasks/transcribe.md
+++ b/docs/mkdocs/tasks/transcribe.md
@@ -60,6 +60,7 @@ Any HuggingFace [`automatic-speech-recognition`](https://huggingface.co/models?p
         input_ext: .mp3
         output_ext: .txt  # or .srt, .json
         params:
+          allow_fetch: True
           # output_format: text   # (default) plain text
           # output_format: srt    # SRT subtitles (requires return_timestamps)
           # output_format: json   # raw Whisper output with timestamps
@@ -130,6 +131,7 @@ tasks:
     output_ext: .txt
     params:
       language: en
+      allow_fetch: True
 ```
 
 ### Run on HPC with Slurm
@@ -150,4 +152,6 @@ tasks:
       gpus: 1
       memory: 16G
       time: 04:00:00
+    params:
+      cache_dir: ~/path/to/model/hub/
 ```

--- a/src/tigerflow_ml/audio/transcribe/_base.py
+++ b/src/tigerflow_ml/audio/transcribe/_base.py
@@ -78,7 +78,9 @@ class _TranscribeBase:
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import AutoFeatureExtractor, pipeline
+        from transformers import AutoFeatureExtractor, pipeline, set_seed
+
+        set_seed(context.seed)
 
         logger.info("Setting up transcription pipeline...")
         logger.info("Model: {}", context.model)
@@ -92,21 +94,35 @@ class _TranscribeBase:
 
         cache_dir = context.cache_dir or None
 
-        feature_extractor = AutoFeatureExtractor.from_pretrained(
-            context.model,
-            revision=context.revision,
-            cache_dir=cache_dir,
-        )
+        try:
+            feature_extractor = AutoFeatureExtractor.from_pretrained(
+                context.model,
+                revision=context.revision,
+                cache_dir=cache_dir,
+                local_files_only=not context.allow_fetch,
+            )
+            context.pipeline = pipeline(
+                "automatic-speech-recognition",
+                model=context.model,
+                revision=context.revision,
+                device=device_map,
+                torch_dtype=torch_dtype,
+                local_files_only=not context.allow_fetch,
+                model_kwargs={"cache_dir": cache_dir},
+                feature_extractor=feature_extractor,
+            )
+            # Transformers uses kwargs.get() (not pop) for local_files_only in the
+            # pipeline factory, so it leaks into _forward_params and then generate().
+            # Whisper validates generate kwargs strictly and raises; remove it here.
+            context.pipeline._forward_params.pop("local_files_only", None)
 
-        context.pipeline = pipeline(
-            "automatic-speech-recognition",
-            model=context.model,
-            revision=context.revision,
-            device=device_map,
-            torch_dtype=torch_dtype,
-            model_kwargs={"cache_dir": cache_dir},
-            feature_extractor=feature_extractor,
-        )
+        except OSError as e:
+            if not context.allow_fetch:
+                raise RuntimeError(
+                    f"'{context.model}' not found in cache ({context.cache_dir}). "
+                    "Run with --allow_fetch or download manually."
+                ) from e
+            raise
         logger.info("Pipeline ready")
 
     @staticmethod
@@ -120,6 +136,9 @@ class _TranscribeBase:
         generate_kwargs = {}
         if context.language:
             generate_kwargs["language"] = context.language
+        if context.temperature > 0:
+            generate_kwargs["temperature"] = context.temperature
+            generate_kwargs["do_sample"] = True
 
         logger.info(
             "Processing with batch_size={}, chunk_length_s={}",
@@ -139,7 +158,6 @@ class _TranscribeBase:
         }
         if generate_kwargs:
             pipeline_kwargs["generate_kwargs"] = generate_kwargs
-
         result = context.pipeline(str(input_file), **pipeline_kwargs)
 
         if context.output_format == OutputFormat.JSON:

--- a/src/tigerflow_ml/audio/transcribe/_base.py
+++ b/src/tigerflow_ml/audio/transcribe/_base.py
@@ -78,9 +78,7 @@ class _TranscribeBase:
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import AutoFeatureExtractor, pipeline, set_seed
-
-        set_seed(context.seed)
+        from transformers import AutoFeatureExtractor, pipeline
 
         logger.info("Setting up transcription pipeline...")
         logger.info("Model: {}", context.model)
@@ -136,9 +134,6 @@ class _TranscribeBase:
         generate_kwargs = {}
         if context.language:
             generate_kwargs["language"] = context.language
-        if context.temperature > 0:
-            generate_kwargs["temperature"] = context.temperature
-            generate_kwargs["do_sample"] = True
 
         logger.info(
             "Processing with batch_size={}, chunk_length_s={}",

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -68,11 +68,23 @@ class _DetectBase:
             ),
         ] = 1.0
 
+        # override to remove help message
+        seed: Annotated[
+            int,
+            typer.Option(hidden=True),
+        ] = 42
+        # override to remove help message
+        temperature: Annotated[
+            int,
+            typer.Option(hidden=True),
+        ] = 0  # unused
+
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import AutoConfig, pipeline
+        from transformers import AutoConfig, pipeline, set_seed
 
+        set_seed(context.seed)
         logger.info("Setting up detection model...")
         logger.info("Model: {}", context.model)
 
@@ -80,11 +92,21 @@ class _DetectBase:
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        config = AutoConfig.from_pretrained(
-            context.model,
-            revision=context.revision,
-            cache_dir=context.cache_dir or None,
-        )
+        try:
+            config = AutoConfig.from_pretrained(
+                context.model,
+                revision=context.revision,
+                cache_dir=context.cache_dir or None,
+                local_files_only=not context.allow_fetch,
+            )
+        except OSError as e:
+            if not context.allow_fetch:
+                raise RuntimeError(
+                    f"'{context.model}' not found in cache ({context.cache_dir}). "
+                    "Run with --allow_fetch or download manually."
+                ) from e
+            raise
+
         is_zero_shot = config.model_type in _ZERO_SHOT_MODEL_TYPES
 
         if is_zero_shot and not context.labels:
@@ -99,13 +121,23 @@ class _DetectBase:
         )
         logger.info("Pipeline: {} (model_type: {})", pipeline_type, config.model_type)
 
-        context.pipeline = pipeline(
-            pipeline_type,
-            model=context.model,
-            revision=context.revision,
-            device=device,
-            model_kwargs={"cache_dir": context.cache_dir or None},
-        )
+        try:
+            context.pipeline = pipeline(
+                pipeline_type,
+                model=context.model,
+                revision=context.revision,
+                device=device,
+                local_files_only=not context.allow_fetch,
+                model_kwargs={"cache_dir": context.cache_dir or None},
+            )
+        except OSError as e:
+            if not context.allow_fetch:
+                raise RuntimeError(
+                    f"'{context.model}' not found in cache ({context.cache_dir}). "
+                    "Run with --allow_fetch or download manually."
+                ) from e
+            raise
+
         context.is_zero_shot = is_zero_shot
         context.labels_list = (
             [s.strip() for s in context.labels.split(",") if s.strip()]

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -68,23 +68,11 @@ class _DetectBase:
             ),
         ] = 1.0
 
-        # override to remove help message
-        seed: Annotated[
-            int,
-            typer.Option(hidden=True),
-        ] = 42
-        # override to remove help message
-        temperature: Annotated[
-            int,
-            typer.Option(hidden=True),
-        ] = 0  # unused
-
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import AutoConfig, pipeline, set_seed
+        from transformers import AutoConfig, pipeline
 
-        set_seed(context.seed)
         logger.info("Setting up detection model...")
         logger.info("Model: {}", context.model)
 

--- a/src/tigerflow_ml/params.py
+++ b/src/tigerflow_ml/params.py
@@ -28,6 +28,27 @@ class HFParams:
         typer.Option(help="Device to use (cuda, cpu, or auto)"),
     ] = "auto"
 
+    allow_fetch: Annotated[
+        bool,
+        typer.Option(
+            help="Allow downloading from HuggingFace Hub. "
+            "Do not allow if running on a compute node without network access"
+        ),
+    ] = False
+
+    temperature: Annotated[
+        float,
+        typer.Option(
+            help="The model temperature. Lower numbers make models more deterministic",
+            min=0.0,
+            max=2.0,
+        ),
+    ] = 0.0
+
+    seed: Annotated[
+        int, typer.Option(help="The seed to set for more reproducible behavior")
+    ] = 42
+
 
 class VLLMParams:
     """Common parameters for all vLLM tasks"""

--- a/src/tigerflow_ml/params.py
+++ b/src/tigerflow_ml/params.py
@@ -36,19 +36,6 @@ class HFParams:
         ),
     ] = False
 
-    temperature: Annotated[
-        float,
-        typer.Option(
-            help="The model temperature. Lower numbers make models more deterministic",
-            min=0.0,
-            max=2.0,
-        ),
-    ] = 0.0
-
-    seed: Annotated[
-        int, typer.Option(help="The seed to set for more reproducible behavior")
-    ] = 42
-
 
 class VLLMParams:
     """Common parameters for all vLLM tasks"""

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -40,11 +40,6 @@ class _OCRBase:
             typer.Option(help="Maximum number of tokens to generate per image"),
         ] = 4096
 
-        batch_size: Annotated[
-            int,
-            typer.Option(help="Number of images to process in parallel on GPU"),
-        ] = 4
-
         output_format: Annotated[
             OutputFormat,
             typer.Option(help="Output format: 'text', 'markdown', or 'json'"),
@@ -58,7 +53,9 @@ class _OCRBase:
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import pipeline
+        from transformers import pipeline, set_seed
+
+        set_seed(context.seed)
 
         logger.info("Setting up OCR model...")
         logger.info("Model: {}", context.model)
@@ -67,13 +64,22 @@ class _OCRBase:
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        context.pipeline = pipeline(
-            "image-text-to-text",
-            model=context.model,
-            revision=context.revision,
-            device=device,
-            model_kwargs={"cache_dir": context.cache_dir or None},
-        )
+        try:
+            context.pipeline = pipeline(
+                "image-text-to-text",
+                model=context.model,
+                revision=context.revision,
+                device=device,
+                local_files_only=not context.allow_fetch,
+                model_kwargs={"cache_dir": context.cache_dir or None},
+            )
+        except OSError as e:
+            if not context.allow_fetch:
+                raise RuntimeError(
+                    f"'{context.model}' not found in cache ({context.cache_dir}). "
+                    "Run with --allow_fetch or download manually."
+                ) from e
+            raise
         logger.info("OCR ready on device: {}", device)
 
     @staticmethod
@@ -98,10 +104,11 @@ class _OCRBase:
                     ],
                 }
             ]
-            result = context.pipeline(
-                text=messages,
-                max_new_tokens=context.max_length,
-            )
+            gen_kwargs: dict = {"max_new_tokens": context.max_length}
+            if context.temperature > 0:
+                gen_kwargs["temperature"] = context.temperature
+                gen_kwargs["do_sample"] = True
+            result = context.pipeline(text=messages, **gen_kwargs)
             text = result[0]["generated_text"][-1]["content"]
             pages.append(text)
             logger.info("Page {}: {} chars", i + 1, len(text))

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -50,6 +50,20 @@ class _OCRBase:
             typer.Option(help="Prompt for image-text-to-text models"),
         ] = _DEFAULT_PROMPT
 
+        temperature: Annotated[
+            float,
+            typer.Option(
+                help="The model temperature. "
+                "Lower values make models more deterministic",
+                min=0.0,
+                max=2.0,
+            ),
+        ] = 0.0
+
+        seed: Annotated[
+            int, typer.Option(help="The seed to set for more reproducible behavior")
+        ] = 42
+
     @staticmethod
     def setup(context: SetupContext):
         import torch

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -14,6 +14,8 @@ def test_ocr_defaults():
     assert p.max_length == 4096
     assert p.output_format == OutputFormat.TEXT
     assert p.device == "auto"
+    assert p.temperature == 0
+    assert p.seed == 42
 
 
 def test_transcribe_defaults():
@@ -55,5 +57,3 @@ def test_hfparams_defaults():
     assert p.cache_dir is None
     assert p.allow_fetch is False
     assert p.device == "auto"
-    assert p.temperature == 0
-    assert p.seed == 42

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -2,7 +2,7 @@
 
 from tigerflow_ml.audio.transcribe._base import _TranscribeBase
 from tigerflow_ml.image.detect._base import _DetectBase
-from tigerflow_ml.params import VLLMParams
+from tigerflow_ml.params import HFParams, VLLMParams
 from tigerflow_ml.text.ocr._base import _OCRBase
 
 
@@ -47,3 +47,13 @@ def test_vLLM_defaults():
     assert p.llm_kwargs == "{}"
     assert p.sampling_kwargs == "{}"
     assert p.chat_kwargs == "{}"
+
+
+def test_hfparams_defaults():
+    p = HFParams()
+    assert p.revision == "main"
+    assert p.cache_dir is None
+    assert p.allow_fetch is False
+    assert p.device == "auto"
+    assert p.temperature == 0
+    assert p.seed == 42

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -12,7 +12,6 @@ def test_ocr_defaults():
     p = _OCRBase.Params()
     assert p.model == "stepfun-ai/GOT-OCR-2.0-hf"
     assert p.max_length == 4096
-    assert p.batch_size == 4
     assert p.output_format == OutputFormat.TEXT
     assert p.device == "auto"
 


### PR DESCRIPTION
Adds the arguments `seed`, `temperature`, and `allow-fetch` to `HFParams`. The `OCR` and `transcribe` tasks have been modified to use all these parameters. `Temperature` and `seed` do not appear to have any impact on detection models, so this tasks does not use these parameters.

The unused `batch-size` parameter was also removed from the OCR task. 