### PR TITLE
refactor(ocr)!: remove structured output support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ htmlcov/
 *.out
 *.err
 *.txt
+dev_tests/
 
 # Type checking
 .ty/

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -10,7 +10,6 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 | `--revision`      | `main`                        | Model revision (branch, tag, or commit hash)   |
 | `--cache-dir`     |                               | HuggingFace cache directory for model files    |
 | `--device`        | `auto`                        | Device to use (`cuda`, `cpu`, or `auto`)       |
-| `--output-format` | `text`                        | Output format: `text`, `markdown`, or `json`   |
 | `--max-length`    | `4096`                        | Maximum number of tokens to generate per image |
 | `--batch-size`    | `4`                           | Number of images to process in parallel on GPU |
 | `--prompt`        | `Extract all text from this image.` | Prompt for image-text-to-text models     |
@@ -22,11 +21,7 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 
 ## Output Format
 
-Depends on `--output-format`:
-
-- **`text`** (default) — Plain text. For multi-page inputs, pages are separated by form-feed characters (`\f`).
-- **`markdown`** — Formatted output preserving tables, equations, and document structure as markdown/LaTeX.
-- **`json`** — Structured JSON with per-page text: `{"pages": [{"page": 1, "text": "..."}, ...]}`.
+Plain text. For multi-page inputs, pages are separated by form-feed characters (`\f`).
 
 ## Models
 
@@ -39,10 +34,6 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
 | [`zai-org/GLM-4.1V-9B-Thinking`](https://huggingface.co/zai-org/GLM-4.1V-9B-Thinking) | 10B | Bilingual (English/Chinese) VLM with reasoning, up to 4K image resolution | MIT |
 | [`Qwen/Qwen2.5-VL-7B-Instruct`](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct) | 7B | General-purpose VLM with strong OCR and multilingual support | Apache 2.0 |
 
-!!! tip
-
-    GOT-OCR supports plain text and formatted (markdown/LaTeX) output. Use
-    `--output-format markdown` to preserve tables, equations, and document structure.
 
 ## Examples
 
@@ -56,11 +47,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         kind: local
         module: tigerflow_ml.text.ocr.local
         input_ext: .jpg
-        output_ext: .txt  # or .md, .json
-        params:
-          # output_format: text       # (default) plain text
-          # output_format: markdown   # formatted markdown/LaTeX
-          # output_format: json       # structured JSON with pages
+        output_ext: .txt
     ```
 
 === "Input"
@@ -119,9 +106,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         kind: local
         module: tigerflow_ml.text.ocr.local
         input_ext: .png
-        output_ext: .md
-        params:
-          output_format: markdown
+        output_ext: .txt
     ```
 
 === "Input"

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -4,8 +4,6 @@ Perform OCR on images using Hugging Face image-text-to-text models.
 Supports VLMs compatible with the image-text-to-text pipeline.
 """
 
-import json
-from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
@@ -16,14 +14,6 @@ from tigerflow.utils import SetupContext
 from tigerflow_ml.params import HFParams
 
 _DEFAULT_PROMPT = "Extract all text from this image."
-
-
-class OutputFormat(str, Enum):
-    """Output format for OCR results."""
-
-    TEXT = "text"
-    MARKDOWN = "markdown"
-    JSON = "json"
 
 
 class _OCRBase:
@@ -44,11 +34,6 @@ class _OCRBase:
             int,
             typer.Option(help="Number of images to process in parallel on GPU"),
         ] = 4
-
-        output_format: Annotated[
-            OutputFormat,
-            typer.Option(help="Output format: 'text', 'markdown', or 'json'"),
-        ] = OutputFormat.TEXT
 
         prompt: Annotated[
             str,
@@ -82,10 +67,7 @@ class _OCRBase:
         images = _load_images(input_file)
         logger.info("Loaded {} image(s)", len(images))
 
-        # Determine effective prompt
         prompt = context.prompt
-        if context.output_format == OutputFormat.MARKDOWN and prompt == _DEFAULT_PROMPT:
-            prompt = "OCR with format"
 
         pages = []
         for i, image in enumerate(images):
@@ -106,14 +88,7 @@ class _OCRBase:
             pages.append(text)
             logger.info("Page {}: {} chars", i + 1, len(text))
 
-        if context.output_format == OutputFormat.JSON:
-            output_text = json.dumps(
-                {"pages": [{"page": i + 1, "text": p} for i, p in enumerate(pages)]},
-                indent=2,
-                ensure_ascii=False,
-            )
-        else:
-            output_text = "\f".join(pages)
+        output_text = "\f".join(pages)
 
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(output_text)

--- a/tests/integration/test_ocr.py
+++ b/tests/integration/test_ocr.py
@@ -1,10 +1,8 @@
 """Integration tests for OCR task."""
 
-import json
-
 import pytest
 
-from tigerflow_ml.text.ocr._base import OutputFormat, _OCRBase
+from tigerflow_ml.text.ocr._base import _OCRBase
 
 _context = None
 _json_context = None
@@ -17,15 +15,6 @@ def test_setup(make_context):
     _OCRBase.setup(_context)
 
 
-@pytest.mark.dependency()
-def test_setup_json_format(make_context):
-    global _json_context
-    _json_context = make_context(
-        _OCRBase.Params, "ocr", output_format=OutputFormat.JSON
-    )
-    _OCRBase.setup(_json_context)
-
-
 @pytest.mark.dependency(depends=["test_setup"])
 def test_run(ocr_dir, get_input_files, make_output_path):
     for input_file in get_input_files(ocr_dir):
@@ -35,18 +24,3 @@ def test_run(ocr_dir, get_input_files, make_output_path):
         assert output_file.exists(), f"No output for {input_file.name}"
         text = output_file.read_text(encoding="utf-8")
         assert len(text.strip()) > 0, f"Empty output for {input_file.name}"
-
-
-@pytest.mark.dependency(depends=["test_setup_json_format"])
-def test_run_json_format(ocr_dir, get_input_files, make_output_path):
-    for input_file in get_input_files(ocr_dir):
-        output_file = make_output_path(input_file, ".json")
-        _OCRBase.run(_json_context, input_file, output_file)
-
-        data = json.loads(output_file.read_text(encoding="utf-8"))
-        assert "pages" in data
-        assert isinstance(data["pages"], list)
-        assert len(data["pages"]) > 0
-        for page in data["pages"]:
-            assert "page" in page
-            assert "text" in page

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -7,13 +7,10 @@ from tigerflow_ml.text.ocr._base import _OCRBase
 
 
 def test_ocr_defaults():
-    from tigerflow_ml.text.ocr._base import OutputFormat
-
     p = _OCRBase.Params()
     assert p.model == "stepfun-ai/GOT-OCR-2.0-hf"
     assert p.max_length == 4096
     assert p.batch_size == 4
-    assert p.output_format == OutputFormat.TEXT
     assert p.device == "auto"
 
 


### PR DESCRIPTION
Removes support for user provided output formats for release v0.1.0 (#89). These were not robustly implemented and will be revisited at a later date. 

Note: Running this code on Della does not work without setting `local_files_only=True`. Known bug that is fixed in #102 