### PR TITLE
refactor!: remove model defaults from all tasks

### DIFF
--- a/docs/mkdocs/tasks/chat_completion.md
+++ b/docs/mkdocs/tasks/chat_completion.md
@@ -119,21 +119,21 @@ Any HuggingFace model that is compatible with vLLM's `LLM.chat()`.
             output_ext: .txt
             max_workers: 1
             worker_resources:
-            cpus: 1
-            gpus: 1
-            memory: 10G
-            time: 00:10:00
-            sbatch_options:
-                - "--constraint=gpu80"
+                cpus: 1
+                gpus: 1
+                memory: 10G
+                time: 00:10:00
+                sbatch_options:
+                    - "--constraint=gpu80"
             setup_commands:
-            - source ~/github/tigerflow-ml/.venv/bin/activate
-            - export VLLM_USE_FLASHINFER_SAMPLER=0
+                - source ~/github/tigerflow-ml/.venv/bin/activate
+                - export VLLM_USE_FLASHINFER_SAMPLER=0
             params:
-            model: Qwen/Qwen2.5-VL-7B-Instruct
-            cache-dir: ~/github/tigerflow-ml/.hf/hub/
-            prompt: 'Caption this image'
-            max-image-pixels: 500
-            chat-kwargs: {"use_tqdm":True}
+                model: Qwen/Qwen2.5-VL-7B-Instruct
+                cache-dir: ~/github/tigerflow-ml/.hf/hub/
+                prompt: 'Caption this image'
+                max-image-pixels: 500
+                chat-kwargs: {"use_tqdm":True}
     ```
 
 === "Input (.jpeg)"

--- a/docs/mkdocs/tasks/detect.md
+++ b/docs/mkdocs/tasks/detect.md
@@ -9,7 +9,7 @@ Supports both fixed-class models (e.g. RT-DETR) and open-vocabulary models
 
 | Parameter      | Default                | Description                                                            |
 |----------------|------------------------|------------------------------------------------------------------------|
-| `--model`      | `PekingU/rtdetr_r50vd` | HuggingFace model repo ID                                              |
+| `--model`      |                        | HuggingFace model repo ID                                              |
 | `--revision`   | `main`                 | Model revision (branch, tag, or commit hash)                           |
 | `--cache-dir`  |                        | HuggingFace cache directory for model files                            |
 | `--device`     | `auto`                 | Device to use (`cuda`, `cpu`, or `auto`)                               |
@@ -67,7 +67,7 @@ These models detect a fixed set of object categories without needing `--labels`.
 
 | Model | Params | COCO AP | License |
 |-------|--------|---------|---------|
-| [`PekingU/rtdetr_r50vd`](https://huggingface.co/PekingU/rtdetr_r50vd) (default) | 42M | 53.1 | Apache 2.0 |
+| [`PekingU/rtdetr_r50vd`](https://huggingface.co/PekingU/rtdetr_r50vd) | 42M | 53.1 | Apache 2.0 |
 | [`facebook/detr-resnet-50`](https://huggingface.co/facebook/detr-resnet-50) | 41M | 42.0 | Apache 2.0 |
 
 ### Zero-shot (open vocabulary)
@@ -84,7 +84,7 @@ These models detect any object described by text. Requires `--labels`.
 
 ### Detect objects in images
 
-Uses the default RT-DETR model which recognizes 80 common object categories (COCO classes).
+Uses the PekingU/rtdetr_r50vd model which recognizes 80 common object categories (COCO classes).
 
 === "Config"
 
@@ -96,6 +96,7 @@ Uses the default RT-DETR model which recognizes 80 common object categories (COC
         input_ext: .jpg
         output_ext: .json
         params:
+          model: PekingU/rtdetr_r50vd
           allow-fetch: True
     ```
 
@@ -178,6 +179,7 @@ runs detection on each frame.
         input_ext: .mp4
         output_ext: .json
         params:
+          model: PekingU/rtdetr_r50vd
           sample_fps: 2.0
           batch_size: 8
           allow-fetch: True
@@ -232,6 +234,7 @@ tasks:
       memory: 16G
       time: 04:00:00
     params:
+      model: PekingU/rtdetr_r50vd
       sample_fps: 1.0
       batch_size: 8
       cache_dir: ~/path/to/model/hub

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -6,7 +6,7 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 
 | Parameter         | Default                       | Description                                    |
 |-------------------|-------------------------------|------------------------------------------------|
-| `--model`         | `stepfun-ai/GOT-OCR-2.0-hf`  | HuggingFace model repo ID                      |
+| `--model`         |                               | HuggingFace model repo ID                      |
 | `--revision`      | `main`                        | Model revision (branch, tag, or commit hash)   |
 | `--cache-dir`     |                               | HuggingFace cache directory for model files    |
 | `--device`        | `auto`                        | Device to use (`cuda`, `cpu`, or `auto`)       |
@@ -32,7 +32,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
 
 | Model | Params | Description | License |
 |-------|--------|-------------|---------|
-| [`stepfun-ai/GOT-OCR-2.0-hf`](https://huggingface.co/stepfun-ai/GOT-OCR-2.0-hf) (default) | 600M | Full-page OCR with format preservation | Apache 2.0 |
+| [`stepfun-ai/GOT-OCR-2.0-hf`](https://huggingface.co/stepfun-ai/GOT-OCR-2.0-hf) | 600M | Full-page OCR with format preservation | Apache 2.0 |
 | [`rednote-hilab/dots.ocr`](https://huggingface.co/rednote-hilab/dots.ocr) | 3B | Multilingual document parsing (100+ languages) with layout detection | MIT |
 | [`zai-org/GLM-4.1V-9B-Thinking`](https://huggingface.co/zai-org/GLM-4.1V-9B-Thinking) | 10B | Bilingual (English/Chinese) VLM with reasoning, up to 4K image resolution | MIT |
 | [`Qwen/Qwen2.5-VL-7B-Instruct`](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct) | 7B | General-purpose VLM with strong OCR and multilingual support | Apache 2.0 |
@@ -51,6 +51,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         module: tigerflow_ml.text.ocr.local
         input_ext: .jpg
         params:
+          model: stepfun-ai/GOT-OCR-2.0-hf
           allow-fetch: True #if model is not already downloaded
     ```
 
@@ -112,6 +113,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         input_ext: .png
         output_ext: .txt
         params:
+          model: stepfun-ai/GOT-OCR-2.0-hf
           allow_fetch: True
     ```
 
@@ -188,6 +190,7 @@ Any HuggingFace [`image-text-to-text`](https://huggingface.co/models?pipeline_ta
         input_ext: .pdf
         output_ext: .txt
         params:
+          model: stepfun-ai/GOT-OCR-2.0-hf
           allow_fetch: True
     ```
 
@@ -253,5 +256,6 @@ tasks:
       memory: 16G
       time: 04:00:00
     params:
+      model: stepfun-ai/GOT-OCR-2.0-hf
       cache_dir: ~/path/to/model/hub/
 ```

--- a/docs/mkdocs/tasks/transcribe.md
+++ b/docs/mkdocs/tasks/transcribe.md
@@ -6,7 +6,7 @@ Transcribe audio to text using HuggingFace Whisper models.
 
 | Parameter             | Default                   | Description                                                   |
 |-----------------------|---------------------------|---------------------------------------------------------------|
-| `--model`             | `openai/whisper-large-v3` | HuggingFace model repo ID                                    |
+| `--model`             |                           | HuggingFace model repo ID                                    |
 | `--revision`          | `main`                    | Model revision (branch, tag, or commit hash)                  |
 | `--cache-dir`         |                           | HuggingFace cache directory for model files                   |
 | `--device`            | `auto`                    | Device to use (`cuda`, `cpu`, or `auto`)                      |
@@ -32,7 +32,7 @@ Any HuggingFace [`automatic-speech-recognition`](https://huggingface.co/models?p
 
 | Model | Params | Speed | License |
 |-------|--------|-------|---------|
-| [`openai/whisper-large-v3`](https://huggingface.co/openai/whisper-large-v3) (default) | 1.5B | 1x | Apache 2.0 |
+| [`openai/whisper-large-v3`](https://huggingface.co/openai/whisper-large-v3) | 1.5B | 1x | Apache 2.0 |
 | [`openai/whisper-large-v3-turbo`](https://huggingface.co/openai/whisper-large-v3-turbo) | 809M | 3x | MIT |
 | [`openai/whisper-medium`](https://huggingface.co/openai/whisper-medium) | 769M | 4x | MIT |
 | [`openai/whisper-small`](https://huggingface.co/openai/whisper-small) | 244M | 9x | MIT |
@@ -58,6 +58,7 @@ Any HuggingFace [`automatic-speech-recognition`](https://huggingface.co/models?p
         input_ext: .mp3
         output_ext: .txt  # or .srt, .json
         params:
+          model: openai/whisper-large-v3
           allow_fetch: True
           # output_format: text   # (default) plain text
           # output_format: srt    # SRT subtitles (requires return_timestamps)
@@ -128,6 +129,7 @@ tasks:
     input_ext: .mp3
     output_ext: .txt
     params:
+      model: openai/whisper-large-v3
       language: en
       allow_fetch: True
 ```
@@ -151,5 +153,6 @@ tasks:
       memory: 16G
       time: 04:00:00
     params:
+      model: openai/whisper-large-v3
       cache_dir: ~/path/to/model/hub/
 ```

--- a/src/tigerflow_ml/audio/transcribe/_base.py
+++ b/src/tigerflow_ml/audio/transcribe/_base.py
@@ -28,11 +28,6 @@ class _TranscribeBase:
     """Transcribe audio to text using Hugging Face Whisper models."""
 
     class Params(HFParams):
-        model: Annotated[
-            str,
-            typer.Option(help="HuggingFace model repo ID"),
-        ] = "openai/whisper-large-v3"
-
         language: Annotated[
             str,
             typer.Option(

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -36,11 +36,6 @@ class _DetectBase:
     """Detect objects in images and videos using HuggingFace detection models."""
 
     class Params(HFParams):
-        model: Annotated[
-            str,
-            typer.Option(help="HuggingFace model repo ID"),
-        ] = "PekingU/rtdetr_r50vd"
-
         labels: Annotated[
             str,
             typer.Option(

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -20,11 +20,6 @@ class _OCRBase:
     """Extract text from images using image-text-to-text models."""
 
     class Params(HFParams):
-        model: Annotated[
-            str,
-            typer.Option(help="HuggingFace model repo ID"),
-        ] = "stepfun-ai/GOT-OCR-2.0-hf"
-
         max_length: Annotated[
             int,
             typer.Option(help="Maximum number of tokens to generate per image"),

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -8,7 +8,6 @@ from tigerflow_ml.text.ocr._base import _OCRBase
 
 def test_ocr_defaults():
     p = _OCRBase.Params()
-    assert p.model == "stepfun-ai/GOT-OCR-2.0-hf"
     assert p.max_length == 4096
     assert p.device == "auto"
     assert p.temperature == 0
@@ -17,7 +16,6 @@ def test_ocr_defaults():
 
 def test_transcribe_defaults():
     p = _TranscribeBase.Params()
-    assert p.model == "openai/whisper-large-v3"
     assert p.batch_size == 16
     assert p.chunk_length_s == 30.0
     assert p.stride_length_s == 5.0
@@ -26,7 +24,6 @@ def test_transcribe_defaults():
 
 def test_detect_defaults():
     p = _DetectBase.Params()
-    assert p.model == "PekingU/rtdetr_r50vd"
     assert p.threshold == 0.3
     assert p.batch_size == 4
     assert p.sample_fps == 1.0


### PR DESCRIPTION
Removes the default models from `detect`, `OCR`, and `transcribe` tasks. This matches the pattern for `translate` and `chat_completion`, and ensures default models (implicitly recommended models) won't become outdated. 

Ref #11 
