### PR TITLE
ci: add integration workflow for self-hosted H100 runner

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   integration:
-    runs-on: [self-hosted, H100]
+    runs-on: [self-hosted, 2xH100]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,47 @@
+name: Integration
+
+# Real-model integration tests run on a self-hosted H100 runner.
+#
+# Triggers are intentionally limited to push-to-main and manual dispatch.
+# This is a public repo, so fork-PR triggers would execute untrusted code
+# on the H100 node — never add `pull_request` here.
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - LICENSE
+  workflow_dispatch:
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_VERSION: "0.7.15"
+
+jobs:
+  integration:
+    runs-on: [self-hosted, H100]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Belt and suspenders: never check out a non-main ref on the
+          # self-hosted runner, even if the trigger somehow changes.
+          ref: main
+
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --locked --group test --extra vllm
+
+      - name: Run integration tests
+        env:
+          TIGERFLOW_ML_INTEGRATION_TESTS: "1"
+        run: uv run pytest tests/integration/


### PR DESCRIPTION
## Summary

Adds the GitHub Actions workflow that runs the integration suite on the self-hosted H100 runner. Triggers on push to main and manual dispatch only — no \`pull_request\` trigger, since this is a public repo and fork-PR runs would execute untrusted code on the H100 node.

Closes #82

## Requires before this is useful

These steps happen outside the repo:

- [x] Register the self-hosted runner on the H100 node with labels \`self-hosted, 2xH100\`
- [x] Verify \`HF_HOME\` is set in the runner's environment so models resolve
- [x] Settings → Actions → Approval policy: "Require approval for first-time contributors" (defense in depth)

## Test plan

- [ ] Trigger via \`workflow_dispatch\` from the Actions tab before relying on push-to-main
- [ ] Confirm all 6 tests pass (5 translate, 1 chat completion); 3 skipped (OCR, detect, transcribe per #84)

## Out of scope

- GPU-selector logic to pin to a single card. vLLM auto-shards across both H100s currently. Revisit if multi-user contention on the node becomes a problem.
- Nightly schedule trigger. Push-to-main coverage is the starting point; add a schedule if regressions slip through.