### PR TITLE
ci: route setup-uv cache through scratch path

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,11 +32,16 @@ jobs:
           # self-hosted runner, even if the trigger somehow changes.
           ref: main
 
+      - name: Propagate runner env to GitHub Actions
+        run: |
+          echo "UV_CACHE_DIR=$UV_CACHE_DIR" >> "$GITHUB_ENV"
+
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v5
         with:
           version: ${{ env.UV_VERSION }}
           python-version-file: ".python-version"
+          cache-local-path: ${{ env.UV_CACHE_DIR }}
 
       - name: Install dependencies
         run: uv sync --locked --group test --extra vllm

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,21 @@ name: Integration
 # Triggers are intentionally limited to push-to-main and manual dispatch.
 # This is a public repo, so fork-PR triggers would execute untrusted code
 # on the H100 node — never add `pull_request` here.
+#
+# Runner setup (one-time, on the H100 node):
+#   1. Register the GitHub Actions runner against
+#      princeton-ddss/tigerflow-ml with labels `self-hosted, 2xH100`.
+#   2. Set these env vars in the runner's environment (systemd drop-in
+#      or equivalent — process env, not shell rc):
+#        HF_HOME=/scratch/.../huggingface     # model weights cache
+#        UV_CACHE_DIR=/scratch/.../uv         # uv's package cache
+#      Both default to ~/.cache/* otherwise, which exceeds home quota
+#      on the cluster.
+#   3. Restart the runner so the env takes effect.
+#
+# Verifying changes to this workflow:
+#   Trigger via `workflow_dispatch` from the Actions tab before relying
+#   on push-to-main, since the workflow only runs on main.
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

Fixes the integration workflow's disk quota failure when downloading torch + nvidia-cuda packages.

The \`setup-uv\` action stages downloads under \`_work/_temp/setup-uv-cache/\` regardless of the process-level \`UV_CACHE_DIR\`. On this runner that path lives in home, which has a low quota on the cluster. Propagate \`UV_CACHE_DIR\` from the runner's environment into \`GITHUB_ENV\` so it's visible to action inputs, then pass it explicitly to \`setup-uv\` via \`cache-local-path\`.

Also adds documentation in the workflow header for runner setup (env vars, labels, verification).

## Test plan

- [ ] After merge, the push-to-main run completes successfully — confirms \`uv sync\` finishes without quota errors and the integration suite passes

Refs #82