### PR TITLE
refactor(ocr)!: switch from pipeline to vllm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ ML tasks for [TigerFlow](https://github.com/princeton-ddss/tigerflow) — privat
 pip install tigerflow-ml
 ```
 
+If using a task that relies on `vllm` (chat completion, OCR, or translation), install with:
+
+```bash
+pip install tigerflow-ml[vllm]
+```
+
+
 ## Tasks
 
 | Task             | Description                           | Entry Point                       |

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -49,7 +49,7 @@ TigerFlow ML requires [TigerFlow](https://github.com/princeton-ddss/tigerflow) t
 pip install tigerflow tigerflow-ml
 ```
 
-If using a task that relies on `vllm` (chat completion or translation), install with:
+If using a task that relies on `vllm` (chat completion, OCR, or translation), install with:
 
 ```bash
 pip install tigerflow-ml[vllm]

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -4,17 +4,21 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 
 ## Parameters
 
-| Parameter         | Default                       | Description                                    |
-|-------------------|-------------------------------|------------------------------------------------|
-| `--model`         |                               | HuggingFace model repo ID                      |
-| `--revision`      | `main`                        | Model revision (branch, tag, or commit hash)   |
-| `--cache-dir`     |                               | HuggingFace cache directory for model files    |
-| `--device`        | `auto`                        | Device to use (`cuda`, `cpu`, or `auto`)       |
-| `--max-length`    | `4096`                        | Maximum number of tokens to generate per image |
-| `--prompt`        | `Extract all text from this image.` | Prompt for image-text-to-text models     |
-| `--temperature`   | `0.0`                         | Sampling temperature. Lower values make output more deterministic. |
-| `--seed`          | `42`                          | Random seed for reproducibility |
-| `--allow-fetch`   | `--no-allow-fetch`            | Allow downloads from HuggingFace Hub (network access required) |
+| Parameter         | Default                       | Description                                                                                        |
+|-------------------|-------------------------------|----------------------------------------------------------------------------------------------------|
+| `--model`         |                               | HuggingFace model repo ID                                                                          |
+| `--revision`      | `main`                        | Model revision (branch, tag, or commit hash)                                                       |
+| `--cache-dir`     |                               | HuggingFace cache directory for model files                                                        |
+| `--allow-fetch`   | `--no-allow-fetch`            | Allow downloads from HuggingFace Hub (network access required)                                     |
+| `--system-message` |                              | System message for chat models                                                                     |
+| `--max-tokens`    | `4096`                        | Maximum number of tokens to generate per image                                                     |
+| `--max-model-len` |                               | Maximum sequence length (input + output tokens) passed to vLLM. Set this for large-context models to avoid OOM. |
+| `--temperature`   | `0`                           | The model temperature. Lower numbers make models more deterministic                                |
+| `--seed`          | `42`                          | The seed to set for more reproducible behavior                                                     |
+| `--llm-kwargs`    | `{}`                          | Additional kwargs for vLLM's LLM() constructor. Supplied values override task defaults.            |
+| `--sampling-kwargs` | `{}`                        | Additional kwargs for vLLM's SamplingParams() constructor. Supplied values override task defaults. |
+| `--chat-kwargs`   | `{}`                          | Additional kwargs for vLLM's LLM.chat(). Supplied values override task defaults.                   |
+| `--prompt`        | `Extract all text from this image.` | Prompt for image-text-to-text models                                                         |
 
 
 ## Supported Input Formats

--- a/src/tigerflow_ml/audio/transcribe/_base.py
+++ b/src/tigerflow_ml/audio/transcribe/_base.py
@@ -152,8 +152,6 @@ class _TranscribeBase:
             pipeline_kwargs["generate_kwargs"] = generate_kwargs
         result = context.pipeline(str(input_file), **pipeline_kwargs)
 
-        logger.info(f"FULL RESULT: {result}")
-
         if context.output_format == OutputFormat.JSON:
             output_text = json.dumps(result, indent=2)
         elif context.output_format == OutputFormat.SRT:

--- a/src/tigerflow_ml/audio/transcribe/_base.py
+++ b/src/tigerflow_ml/audio/transcribe/_base.py
@@ -152,6 +152,8 @@ class _TranscribeBase:
             pipeline_kwargs["generate_kwargs"] = generate_kwargs
         result = context.pipeline(str(input_file), **pipeline_kwargs)
 
+        logger.info(f"FULL RESULT: {result}")
+
         if context.output_format == OutputFormat.JSON:
             output_text = json.dumps(result, indent=2)
         elif context.output_format == OutputFormat.SRT:

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -35,16 +35,6 @@ class _OCRBase:
             typer.Option(help="Prompt for image-text-to-text models"),
         ] = _DEFAULT_PROMPT
 
-        temperature: Annotated[
-            float,
-            typer.Option(
-                help="The model temperature. "
-                "Lower values make models more deterministic",
-                min=0.0,
-                max=2.0,
-            ),
-        ] = 0.0
-
     @staticmethod
     def setup(context: SetupContext):
         import torch
@@ -74,8 +64,10 @@ class _OCRBase:
         user_llm_kwargs = parse_kwargs(context.llm_kwargs)
         llm_kwargs: dict[str, Any] = {
             "tensor_parallel_size": tp,
-            "max_model_len": context.max_model_len,
+            "use_tqdm_on_load": False,
         }
+        if context.max_model_len is not None:
+            llm_kwargs["max_model_len"] = context.max_model_len
         llm_kwargs.update(user_llm_kwargs)
         logger.info(f"   llm_kwargs={llm_kwargs}")
 
@@ -116,37 +108,37 @@ class _OCRBase:
             )
             messages.append(message)
 
-            output = context.LLM.chat(messages, **context.chat_kwargs)
-            results = [o.outputs[0].text for o in output]
-            for page, result in enumerate(results, start=1):
-                if result.finish_reason == "length":
-                    if page > 1:
-                        msg = (
-                            f"  Output truncated at {context.max_tokens} tokens (page"
-                            f"{page}) — increase --max-tokens and/or --max_model_len "
-                            "for a complete result"
-                        )
-                    else:
-                        msg = (
-                            f"  Output truncated at {context.max_tokens} tokens — "
-                            "increase --max-tokens and/or --max_model_len for a "
-                            "complete result"
-                        )
-                    logger.warning(msg)
-                elif result.finish_reason != "stop":
-                    if page > 1:
-                        msg = (
-                            "Unexpected finish reason on page "
-                            f"{page}: {result.finish_reason!r}"
-                        )
-                    else:
-                        msg = f"Unexpected finish reason: {result.finish_reason!r}"
-                    raise RuntimeError(msg)
+        output = context.LLM.chat(messages, **context.chat_kwargs)
+        completions = [o.outputs[0] for o in output]
+        for page, completion in enumerate(completions, start=1):
+            if completion.finish_reason == "length":
+                if page > 1:
+                    msg = (
+                        f"  Output truncated at {context.max_tokens} tokens (page"
+                        f"{page}) — increase --max-tokens and/or --max_model_len "
+                        "for a complete result"
+                    )
+                else:
+                    msg = (
+                        f"  Output truncated at {context.max_tokens} tokens — "
+                        "increase --max-tokens and/or --max_model_len for a "
+                        "complete result"
+                    )
+                logger.warning(msg)
+            elif completion.finish_reason != "stop":
+                if page > 1:
+                    msg = (
+                        "Unexpected finish reason on page "
+                        f"{page}: {completion.finish_reason!r}"
+                    )
+                else:
+                    msg = f"Unexpected finish reason: {completion.finish_reason!r}"
+                raise RuntimeError(msg)
 
-            output_text = "\f".join(results)
+        output_text = "\f".join(c.text for c in completions)
 
-            with open(output_file, "w", encoding="utf-8") as f:
-                f.write(output_text)
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(output_text)
 
 
 def _load_images(path: Path) -> list:
@@ -179,7 +171,7 @@ def _format_message(
             {
                 "role": "user",
                 "content": [
-                    {"type": "image", "image": image},
+                    {"type": "image_pil", "image_pil": image},
                     {"type": "text", "text": prompt},
                 ],
             },
@@ -189,7 +181,7 @@ def _format_message(
         {
             "role": "user",
             "content": [
-                {"type": "image", "image": image},
+                {"type": "image_pil", "image_pil": image},
                 {"type": "text", "text": prompt},
             ],
         }

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -100,7 +100,7 @@ class _OCRBase:
         logger.info(f"Loaded {len(images)} image(s)")
 
         messages = []
-        for i, image in enumerate(images):
+        for image in images:
             message = _format_message(
                 image=image,
                 prompt=context.prompt,

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -5,13 +5,17 @@ Supports VLMs compatible with the image-text-to-text pipeline.
 """
 
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
-from tigerflow_ml.params import HFParams
+from tigerflow_ml.params import VLLMParams
+from tigerflow_ml.utils import parse_kwargs
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 _DEFAULT_PROMPT = "Extract all text from this image."
 
@@ -19,8 +23,9 @@ _DEFAULT_PROMPT = "Extract all text from this image."
 class _OCRBase:
     """Extract text from images using image-text-to-text models."""
 
-    class Params(HFParams):
-        max_length: Annotated[
+    class Params(VLLMParams):
+        # overrides default
+        max_tokens: Annotated[
             int,
             typer.Option(help="Maximum number of tokens to generate per image"),
         ] = 4096
@@ -43,25 +48,18 @@ class _OCRBase:
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import pipeline, set_seed
-
-        set_seed(context.seed)
+        from huggingface_hub import snapshot_download
+        from vllm import LLM, SamplingParams  # type: ignore
 
         logger.info("Setting up OCR model...")
-        logger.info("Model: {}", context.model)
-
-        device = context.device
-        if device == "auto":
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+        logger.info(f"   Model: {context.model}")
 
         try:
-            context.pipeline = pipeline(
-                "image-text-to-text",
-                model=context.model,
-                revision=context.revision,
-                device=device,
+            resolved_model = snapshot_download(
+                repo_id=context.model,
+                cache_dir=context.cache_dir,
                 local_files_only=not context.allow_fetch,
-                model_kwargs={"cache_dir": context.cache_dir or None},
+                revision=context.revision,
             )
         except OSError as e:
             if not context.allow_fetch:
@@ -70,42 +68,85 @@ class _OCRBase:
                     "Run with --allow_fetch or download manually."
                 ) from e
             raise
-        logger.info("OCR ready on device: {}", device)
+
+        tp = torch.cuda.device_count() or 1
+
+        user_llm_kwargs = parse_kwargs(context.llm_kwargs)
+        llm_kwargs: dict[str, Any] = {
+            "tensor_parallel_size": tp,
+            "max_model_len": context.max_model_len,
+        }
+        llm_kwargs.update(user_llm_kwargs)
+        logger.info(f"   llm_kwargs={llm_kwargs}")
+
+        context.LLM = LLM(model=resolved_model, **llm_kwargs)
+
+        user_sampling_kwargs = parse_kwargs(context.sampling_kwargs)
+        sampling_kwargs: dict[str, Any] = {
+            "temperature": context.temperature,
+            "seed": context.seed,
+            "max_tokens": context.max_tokens,
+        }
+        sampling_kwargs.update(user_sampling_kwargs)
+        logger.info(f"   sampling_kwargs={sampling_kwargs}")
+
+        context.sampling_params = SamplingParams(**sampling_kwargs)
+
+        user_chat_kwargs = parse_kwargs(context.chat_kwargs)
+        context.chat_kwargs = {
+            "sampling_params": context.sampling_params,
+            "use_tqdm": False,
+        }
+        context.chat_kwargs.update(user_chat_kwargs)
+        logger.info(f"   chat_kwargs={context.chat_kwargs}")
+
+        logger.info("Setup complete!")
 
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
-        logger.info("Processing: {}", input_file)
         images = _load_images(input_file)
-        logger.info("Loaded {} image(s)", len(images))
+        logger.info(f"Loaded {len(images)} image(s)")
 
-        prompt = context.prompt
-
-        pages = []
+        messages = []
         for i, image in enumerate(images):
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "image", "image": image},
-                        {"type": "text", "text": prompt},
-                    ],
-                }
-            ]
-            gen_kwargs: dict = {"max_new_tokens": context.max_length}
-            if context.temperature > 0:
-                gen_kwargs["temperature"] = context.temperature
-                gen_kwargs["do_sample"] = True
-            result = context.pipeline(text=messages, **gen_kwargs)
-            text = result[0]["generated_text"][-1]["content"]
-            pages.append(text)
-            logger.info("Page {}: {} chars", i + 1, len(text))
+            message = _format_message(
+                image=image,
+                prompt=context.prompt,
+                system_message=context.system_message,
+            )
+            messages.append(message)
 
-        output_text = "\f".join(pages)
+            output = context.LLM.chat(messages, **context.chat_kwargs)
+            results = [o.outputs[0].text for o in output]
+            for page, result in enumerate(results, start=1):
+                if result.finish_reason == "length":
+                    if page > 1:
+                        msg = (
+                            f"  Output truncated at {context.max_tokens} tokens (page"
+                            f"{page}) — increase --max-tokens and/or --max_model_len "
+                            "for a complete result"
+                        )
+                    else:
+                        msg = (
+                            f"  Output truncated at {context.max_tokens} tokens — "
+                            "increase --max-tokens and/or --max_model_len for a "
+                            "complete result"
+                        )
+                    logger.warning(msg)
+                elif result.finish_reason != "stop":
+                    if page > 1:
+                        msg = (
+                            "Unexpected finish reason on page "
+                            f"{page}: {result.finish_reason!r}"
+                        )
+                    else:
+                        msg = f"Unexpected finish reason: {result.finish_reason!r}"
+                    raise RuntimeError(msg)
 
-        with open(output_file, "w", encoding="utf-8") as f:
-            f.write(output_text)
+            output_text = "\f".join(results)
 
-        logger.info("Done")
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(output_text)
 
 
 def _load_images(path: Path) -> list:
@@ -127,3 +168,29 @@ def _load_images(path: Path) -> list:
     if image.mode != "RGB":
         image = image.convert("RGB")
     return [image]
+
+
+def _format_message(
+    image: "Image.Image", prompt: str, system_message: str | None = None
+) -> list:
+    if system_message:
+        return [
+            {"role": "system", "content": system_message},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": prompt},
+                ],
+            },
+        ]
+
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": prompt},
+            ],
+        }
+    ]

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -3,14 +3,13 @@
 from tigerflow_ml.audio.transcribe._base import _TranscribeBase
 from tigerflow_ml.image.detect._base import _DetectBase
 from tigerflow_ml.params import HFParams, VLLMParams
-from tigerflow_ml.text.ocr._base import _OCRBase
+from tigerflow_ml.text.ocr._base import _DEFAULT_PROMPT, _OCRBase
 
 
 def test_ocr_defaults():
     p = _OCRBase.Params()
-    assert p.max_length == 4096
-    assert p.device == "auto"
-    assert p.temperature == 0
+    assert p.max_tokens == 4096
+    assert p.prompt == _DEFAULT_PROMPT
 
 
 def test_transcribe_defaults():


### PR DESCRIPTION
Updates the OCR task to use vllm -- this provides a speedup and also handles batching internally. Now OCR also supports all of the `VLLMParams`.

Ref #64 