### PR TITLE
refactor: add load_images() to shared utils

### DIFF
--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -5,13 +5,17 @@ Supports VLMs compatible with the image-text-to-text pipeline.
 """
 
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
+from tigerflow_ml.utils import load_images
+
+if TYPE_CHECKING:
+    pass
 
 _DEFAULT_PROMPT = "Extract all text from this image."
 
@@ -74,9 +78,8 @@ class _OCRBase:
 
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
-        logger.info("Processing: {}", input_file)
-        images = _load_images(input_file)
-        logger.info("Loaded {} image(s)", len(images))
+        images = load_images(input_file)
+        logger.info(f"Loaded {len(images)} image(s)")
 
         prompt = context.prompt
 
@@ -106,24 +109,3 @@ class _OCRBase:
             f.write(output_text)
 
         logger.info("Done")
-
-
-def _load_images(path: Path) -> list:
-    """Load images from a file. Supports image files and PDFs."""
-    from PIL import Image
-
-    if path.suffix.lower() == ".pdf":
-        import pymupdf
-
-        images = []
-        with pymupdf.open(path) as doc:
-            for page in doc:
-                pix = page.get_pixmap()
-                image = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
-                images.append(image)
-        return images
-
-    image = Image.open(path)
-    if image.mode != "RGB":
-        image = image.convert("RGB")
-    return [image]

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 from tigerflow.logconfig import logger
 
 if TYPE_CHECKING:
+    from PIL import Image
     from transformers import PretrainedConfig, PreTrainedTokenizerBase
 
 
@@ -87,6 +88,45 @@ def read_text_file_strict(path: Path) -> str:
     if not content.strip():
         raise EmptyFileError(f"File is empty: {path}")
     return content
+
+
+def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"]:
+    """Load images from a file. Supports image files and PDFs.
+
+    Args:
+        path: Path to the file to read.
+        max_images: The maximum number of images to return if input is a PDF.
+            Defaults to None (returns all).
+
+    Returns:
+        A list of PIL images of length <= max_images.
+
+    Raises:
+        ValueError: If max_images is less than 1
+    """
+    from PIL import Image
+
+    if max_images is not None and max_images < 1:
+        raise ValueError(f"max_images must be greater than 0. Received {max_images}")
+
+    if path.suffix.lower() == ".pdf":
+        import pymupdf
+
+        limit = max_images if max_images is not None else float("inf")
+        images = []
+        with pymupdf.open(path) as doc:
+            for count, page in enumerate(doc, start=1):
+                if count > limit:
+                    break
+                pix = page.get_pixmap()
+                image = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
+                images.append(image)
+        return images
+
+    image = Image.open(path)
+    if image.mode != "RGB":
+        image = image.convert("RGB")
+    return [image]
 
 
 def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -90,6 +90,9 @@ def read_text_file_strict(path: Path) -> str:
     return content
 
 
+_IMG_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp", ".pdf"]
+
+
 def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"]:
     """Load images from a file. Supports image files and PDFs.
 
@@ -105,6 +108,12 @@ def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"
         ValueError: If max_images is less than 1
     """
     from PIL import Image
+
+    if path.suffix.lower() not in _IMG_EXTENSIONS:
+        raise ValueError(
+            f"{path.suffix} is not a valid file type -- please choose "
+            f"one of: {_IMG_EXTENSIONS}"
+        )
 
     if max_images is not None and max_images < 1:
         raise ValueError(f"max_images must be greater than 0. Received {max_images}")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,6 +12,7 @@ from tigerflow_ml.utils import (
     get_model_config,
     get_model_context_window,
     get_tokenizer,
+    load_images,
     read_text_file_strict,
     read_text_file_with_fallback,
 )
@@ -192,6 +193,61 @@ class TestGetTokenizer:
             "some/model", cache_dir="/cache", revision=None
         )
         assert mock_load.call_count == 2
+
+
+def _make_image_file(path, mode="RGB", color="red", size=(10, 10)):
+    from PIL import Image
+
+    Image.new(mode, size, color=color).save(path)
+    return path
+
+
+def _make_pdf_file(path, num_pages=1):
+    import pymupdf
+
+    doc = pymupdf.open()
+    for _ in range(num_pages):
+        doc.new_page()
+    doc.save(path)
+    doc.close()
+    return path
+
+
+class TestLoadImages:
+    def test_converts_non_rgb_image_to_rgb(self, tmp_path):
+        path = _make_image_file(tmp_path / "test.png", mode="L", color=128)
+        images = load_images(path)
+        assert len(images) == 1
+        assert images[0].mode == "RGB"
+
+    def test_max_images_ignored_for_single_image_file(self, tmp_path):
+        path = _make_image_file(tmp_path / "test.png")
+        images = load_images(path, max_images=5)
+        assert len(images) == 1
+
+    def test_loads_all_pdf_pages_by_default(self, tmp_path):
+        path = _make_pdf_file(tmp_path / "test.pdf", num_pages=3)
+        images = load_images(path)
+        assert len(images) == 3
+        assert all(image.mode == "RGB" for image in images)
+
+    def test_max_images_limits_pdf_pages(self, tmp_path):
+        path = _make_pdf_file(tmp_path / "test.pdf", num_pages=5)
+        images = load_images(path, max_images=2)
+        assert len(images) == 2
+
+    def test_max_images_larger_than_page_count_returns_all(self, tmp_path):
+        path = _make_pdf_file(tmp_path / "test.pdf", num_pages=2)
+        images = load_images(path, max_images=10)
+        assert len(images) == 2
+
+    def test_max_images_zero_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="max_images must be greater than 0"):
+            load_images(tmp_path / "test.pdf", max_images=0)
+
+    def test_max_images_negative_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="max_images must be greater than 0"):
+            load_images(tmp_path / "test.pdf", max_images=-1)
 
 
 class TestGetModelContextWindow:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -249,6 +249,17 @@ class TestLoadImages:
         with pytest.raises(ValueError, match="max_images must be greater than 0"):
             load_images(tmp_path / "test.pdf", max_images=-1)
 
+    def test_only_supports_img_and_pdf_extensions(self, tmp_path):
+        from tigerflow_ml.utils import _IMG_EXTENSIONS
+
+        for ext in _IMG_EXTENSIONS:
+            file = "test" + ext
+            path = _make_image_file(tmp_path / file)
+            images = load_images(path)
+            assert len(images) == 1
+        with pytest.raises(ValueError, match="not a valid file type"):
+            load_images(tmp_path / "test.txt")
+
 
 class TestGetModelContextWindow:
     def test_returns_all_max_len_attributes(self):


### PR DESCRIPTION
Moves the load_images() method to the shared utils file.

Ref https://github.com/princeton-ddss/tigerflow-ml/issues/64