### PR TITLE
refactor(detect): source zero-shot model list from transformers

### DIFF
--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -23,8 +23,6 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
 
-_ZERO_SHOT_MODEL_TYPES = {"grounding-dino", "owlv2", "owlvit"}
-
 _VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
 
 
@@ -70,6 +68,9 @@ class _DetectBase:
     def setup(context: SetupContext):
         import torch
         from transformers import AutoConfig, pipeline, set_seed
+        from transformers.models.auto.modeling_auto import (
+            MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES,
+        )
 
         set_seed(context.seed)
 
@@ -95,7 +96,9 @@ class _DetectBase:
                 ) from e
             raise
 
-        is_zero_shot = config.model_type in _ZERO_SHOT_MODEL_TYPES
+        is_zero_shot = (
+            config.model_type in MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES
+        )
 
         if is_zero_shot and not context.labels:
             msg = (


### PR DESCRIPTION
## Summary
- Replace the hardcoded `_ZERO_SHOT_MODEL_TYPES = {"grounding-dino", "owlv2", "owlvit"}` with `transformers.models.auto.modeling_auto.MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES`.
- New zero-shot architectures (currently `mm-grounding-dino`, `omdet-turbo`, plus any added in future transformers releases) are now picked up automatically.
- Works offline (no Hub call) — the mapping is a static dict shipped with transformers.

## Test plan
- [x] Unit tests pass
- [x] Pre-commit clean
- [x] Verified mapping contents include the three originals plus `mm-grounding-dino` and `omdet-turbo`

Refs #106 