### PR TITLE
feat(detect): add --compile flag

### DIFF
--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -81,6 +81,14 @@ class _DetectBase:
             ),
         ] = Dtype.AUTO
 
+        compile: Annotated[
+            bool,
+            typer.Option(
+                help="Compile the model with torch.compile. Adds 30-60s of "
+                "first-call overhead; worthwhile for long videos."
+            ),
+        ] = False
+
     @staticmethod
     def setup(context: SetupContext):
         import torch
@@ -149,6 +157,15 @@ class _DetectBase:
                     "Run with --allow_fetch or download manually."
                 ) from e
             raise
+
+        if context.compile:
+            try:
+                logger.info("Compiling model with torch.compile...")
+                context.pipeline.model = torch.compile(context.pipeline.model)  # ty: ignore[invalid-assignment]
+            except Exception as e:
+                logger.warning(
+                    "torch.compile failed ({}); falling back to eager model.", e
+                )
 
         context.is_zero_shot = is_zero_shot
         context.labels_list = (


### PR DESCRIPTION
## Summary
- New \`--compile / --no-compile\` flag (default off).
- When set, compiles \`pipeline.model\` with \`torch.compile\` after construction.
- On compile failure, warns and proceeds with the eager model (the always-works path).

Off by default because \`torch.compile\` incurs 30-60s first-call overhead and can fail on exotic models. Worth opting into for long videos.

Part of #106.

## Test plan
- [x] Unit tests pass
- [x] Pre-commit clean