### PR TITLE
refactor(detect): use shared get_model_config helper

### DIFF
--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -99,10 +99,12 @@ class _DetectBase:
     @staticmethod
     def setup(context: SetupContext):
         import torch
-        from transformers import AutoConfig, pipeline, set_seed
+        from transformers import pipeline, set_seed
         from transformers.models.auto.modeling_auto import (
             MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES,
         )
+
+        from tigerflow_ml.utils import get_model_config
 
         set_seed(context.seed)
 
@@ -116,20 +118,12 @@ class _DetectBase:
         torch_dtype = _resolve_dtype(context.dtype, device)
         logger.info(f"Dtype: {torch_dtype}")
 
-        try:
-            config = AutoConfig.from_pretrained(
-                context.model,
-                revision=context.revision,
-                cache_dir=context.cache_dir or None,
-                local_files_only=not context.allow_fetch,
-            )
-        except OSError as e:
-            if not context.allow_fetch:
-                raise RuntimeError(
-                    f"'{context.model}' not found in cache ({context.cache_dir}). "
-                    "Run with --allow_fetch or download manually."
-                ) from e
-            raise
+        config = get_model_config(
+            model=context.model,
+            allow_fetch=context.allow_fetch,
+            cache_dir=context.cache_dir,
+            revision=context.revision,
+        )
 
         is_zero_shot = (
             config.model_type in MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES


### PR DESCRIPTION
## Summary
Drop the hand-rolled \`AutoConfig.from_pretrained\` + \`try/except OSError\` block in setup. Use \`tigerflow_ml.utils.get_model_config\` instead, matching how translate loads its config.

Behavior changes (improvements):
- Missing-cache error is now \`FileNotFoundError\` with a message that points users at \`hf download\` (vs the previous \`RuntimeError\` with a generic message).
- Other config-load failures wrap as \`ModelConfigParsingError\`.

The separate \`try/except\` around \`pipeline(...)\` stays — that path still downloads model weights and needs its own guard.

Part of #106. Closes #99.

## Test plan
- [x] Unit tests pass
- [x] Pre-commit clean