### PR TITLE
fix(detect): use similarity threshold for snapshot comparison

### DIFF
--- a/tests/integration/test_detect.py
+++ b/tests/integration/test_detect.py
@@ -63,6 +63,7 @@ def test_run_image(
             f"detect/{input_file.stem}.json",
             snapshot_dir,
             update_snapshots,
+            threshold=0.9,
         )
 
 
@@ -86,6 +87,7 @@ def test_run_video(
             f"detect/{input_file.stem}.json",
             snapshot_dir,
             update_snapshots,
+            threshold=0.9,
         )
 
 
@@ -122,6 +124,7 @@ def test_run_zero_shot_image(
             f"detect/{input_file.stem}.zero-shot.json",
             snapshot_dir,
             update_snapshots,
+            threshold=0.9,
         )
 
 


### PR DESCRIPTION
## Summary
Integration tests on the H100 runner intermittently fail with snapshot mismatches like:
- \`"score": 0.6011\` → \`0.6055\`
- \`"ymax": 342\` → \`343\`

fp16 inference produces small run-to-run float drift; byte-equal snapshot comparison was too tight. Switch to similarity matching at \`threshold=0.9\`, mirroring how translate handles stochastic LLM output.

Snapshots themselves are unchanged. The current snapshots remain valid as the reference; only the comparison tolerance loosens.

## Test plan
- [x] Unit tests pass, pre-commit clean
- [x] Integration tests pass on H100 (the actual signal we're fixing)