### PR TITLE
refactor!: remove temperature from shared vllm params

### DIFF
--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -13,7 +13,6 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 | `--system-message` |                              | System message for chat models                                                                     |
 | `--max-tokens`    | `4096`                        | Maximum number of tokens to generate per image                                                     |
 | `--max-model-len` |                               | Maximum sequence length (input + output tokens) passed to vLLM. Set this for large-context models to avoid OOM. |
-| `--temperature`   | `0`                           | The model temperature. Lower numbers make models more deterministic                                |
 | `--seed`          | `42`                          | The seed to set for more reproducible behavior                                                     |
 | `--llm-kwargs`    | `{}`                          | Additional kwargs for vLLM's LLM() constructor. Supplied values override task defaults.            |
 | `--sampling-kwargs` | `{}`                        | Additional kwargs for vLLM's SamplingParams() constructor. Supplied values override task defaults. |

--- a/docs/mkdocs/tasks/translate.md
+++ b/docs/mkdocs/tasks/translate.md
@@ -19,7 +19,6 @@ Translate text documents using HuggingFace [vLLM optimized TranslateGemma](https
 | `--prompt-template`  | *(see below)*                    | Prompt template for chat-based models (uses `{source_lang}`, `{target_lang}`, and `{text}`). Ignored for tgemma models.          |
 | `--use-fallback-prompt` | `False`                       | When no source language can be determined and the prompt template uses `{source_lang}`, fall back to a source-language-free prompt (`Translate the following text to {target_lang}…`). Not supported for `tgemma` models. |
 | `--system-message`   |                                  | System message for chat models. Ignored for tgemma models.                                                                       |
-| `--temperature`      | `0.0`                            | Sampling temperature. Lower values make output more deterministic.                                                               |
 | `--seed`             | `42`                             | Random seed for reproducibility                                                                                                  |
 | `--llm-kwargs`       | `{}`                             | JSON string of extra kwargs for vLLM's `LLM()` constructor. Overrides task defaults.                                             |
 | `--sampling-kwargs`  | `{}`                             | JSON string of extra kwargs for vLLM's `SamplingParams()`. Overrides task defaults.                                              |

--- a/src/tigerflow_ml/params.py
+++ b/src/tigerflow_ml/params.py
@@ -85,15 +85,6 @@ class VLLMParams:
         ),
     ] = None
 
-    temperature: Annotated[
-        float,
-        typer.Option(
-            help="The model temperature. Lower numbers make models more deterministic",
-            min=0.0,
-            max=2.0,
-        ),
-    ] = 0.0
-
     seed: Annotated[
         int, typer.Option(help="The seed to set for more reproducible behavior")
     ] = 42

--- a/src/tigerflow_ml/text/chat_completion/_base.py
+++ b/src/tigerflow_ml/text/chat_completion/_base.py
@@ -37,6 +37,16 @@ class _ChatCompletionBase:
             ),
         ] = None
 
+        temperature: Annotated[
+            float,
+            typer.Option(
+                help="The model temperature. Lower numbers make models more"
+                " deterministic",
+                min=0.0,
+                max=2.0,
+            ),
+        ] = 0.0
+
     @staticmethod
     def setup(context: SetupContext):
         import torch

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -83,7 +83,7 @@ class _OCRBase:
 
         user_sampling_kwargs = parse_kwargs(context.sampling_kwargs)
         sampling_kwargs: dict[str, Any] = {
-            "temperature": context.temperature,
+            "temperature": 0,
             "seed": context.seed,
             "max_tokens": context.max_tokens,
         }

--- a/src/tigerflow_ml/text/translate/README.md
+++ b/src/tigerflow_ml/text/translate/README.md
@@ -75,7 +75,6 @@ Some other arguments you can use are:
 - `--prompt-template` : (**not used for tgemma models**) Prompt template for chat-based translation models. Defaults to `Translate the following text from {source_lang} to {target_lang}. Output only the translated text, nothing else. Text: {text}`.
 - `--use-fallback-prompt` : (**not used for tgemma models**) When no source language can be determined and the prompt template uses `{source_lang}`, swap to a source-language-free fallback prompt (`Translate the following text to {target_lang}. Output only the translated text, nothing else. Text: {text}`) for that file instead of raising an error. Disabled by default.
 - `--system-message` : (**not used for tgemma models**) Optional system message for chat models.
-- `--temperature` : Sampling temperature. Lower values make output more deterministic. Defaults to `0.0`.
 - `--seed` : Random seed for reproducibility. Defaults to `42`.
 
 Advanced vLLM options (accept JSON strings):

--- a/src/tigerflow_ml/text/translate/_base.py
+++ b/src/tigerflow_ml/text/translate/_base.py
@@ -178,7 +178,7 @@ class _TranslateBase:
             max_model_len=context.max_model_len,
             config=config,
             seed=context.seed,
-            temperature=context.temperature,
+            temperature=0,
             fetch=context.allow_fetch,
             prompt_template=context.prompt_template,
             system_message=context.system_message,

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -30,7 +30,6 @@ def test_vLLM_defaults():
     assert p.system_message is None
     assert p.max_tokens == 512
     assert p.max_model_len is None
-    assert p.temperature == 0
     assert p.seed == 42
     assert p.llm_kwargs == "{}"
     assert p.sampling_kwargs == "{}"

--- a/tests/unit/text/chat_completion/test_params.py
+++ b/tests/unit/text/chat_completion/test_params.py
@@ -3,15 +3,5 @@ from tigerflow_ml.text.chat_completion._base import _ChatCompletionBase
 
 def test_chat_completion_defaults():
     p = _ChatCompletionBase.Params()
-    assert p.allow_fetch is False
-    assert p.system_message is None
-    assert p.max_tokens == 512
-    assert p.max_model_len is None
     assert p.max_image_pixels is None
-    assert p.revision == "main"
-    assert p.cache_dir is None
     assert p.temperature == 0.0
-    assert p.seed == 42
-    assert p.llm_kwargs == "{}"
-    assert p.sampling_kwargs == "{}"
-    assert p.chat_kwargs == "{}"

--- a/tests/unit/text/translate/test_params.py
+++ b/tests/unit/text/translate/test_params.py
@@ -9,13 +9,5 @@ def test_translate_defaults():
     assert p.max_model_len is None
     assert p.model_backend == "auto"
     assert p.prompt_template == _DEFAULT_PROMPT
-
-    assert p.allow_fetch is False
-    assert p.temperature == 0
-    assert p.seed == 42
-    assert p.system_message is None
-    assert p.revision == "main"
-    assert p.cache_dir is None
-    assert p.llm_kwargs == "{}"
-    assert p.sampling_kwargs == "{}"
-    assert p.chat_kwargs == "{}"
+    assert p.auto_lang_detect is True
+    assert p.use_fallback_prompt is False


### PR DESCRIPTION
Now only `chat_completion` supports a custom temperature, all else are hardcoded to 0. Users could technically override this by using the `--sampling-kwargs` argument. `Do_sample` is not exposed/set since `vllm` handles this internally based on the provided `temperature`.

Closes #13 