### PR TITLE
build: add dependency upper bounds and enable Dependabot (#88, #87)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,3 +61,22 @@ Tasks are registered as `tigerflow.tasks` entry points in `pyproject.toml` (e.g.
 - Python: 3.10–3.13 (tested in matrix)
 - CI runs lockfile check, pre-commit, pytest across Python versions, then builds wheel/sdist
 - CD triggers on GitHub release: publishes to PyPI via trusted publishing
+
+## Dependency Policy
+
+tigerflow-ml is installed into dedicated, per-task environments (not added to
+shared user venvs), so library upper bounds don't cause the resolver collisions
+they would in a general-purpose library.
+
+- **Cap** dependencies whose majors are likely to break us or that have a
+  history of breaking within minors: `tigerflow` (unstabilized internal API),
+  `vllm` (breaks between minors — cap tracks the tested range), and defensive
+  major caps on `transformers` and `torch`.
+- **Leave unbounded** stable libs unlikely to break us: `Pillow`, `pymupdf`,
+  `langdetect`, `opencv-python-headless`, `sentencepiece`, `protobuf`.
+- **Implicit runtime deps** that have no `import` in `src/` but are still
+  required: `timm` (DETR/RT-DETR backbones, detect task) and `accelerate`
+  (transcribe's `from_pretrained(device_map=...)`). Keep them; comments in
+  `pyproject.toml` say why.
+- **Bumping:** Dependabot opens version-bump PRs (`.github/dependabot.yml`);
+  the integration suite verifies them against real models before merge.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot keeps dependencies current as CI-testable PRs.
+# Version bounds live in pyproject.toml (see #88); Dependabot proposes bumps
+# within those bounds and the integration suite verifies them before merge.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,24 +24,24 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "tigerflow>=0.3.1",
-    "transformers>=4.51",
-    "torch>=2.0",
+    "tigerflow>=0.3.1,<0.4",
+    "transformers>=4.51,<6",
+    "torch>=2.0,<3",
     "Pillow",
     "pymupdf>=1.27.1",
     "sentencepiece",
     "opencv-python-headless",
-    "timm",
+    "timm",  # loaded at runtime for DETR/RT-DETR backbones in the detect task
     "langdetect>=1.0.9",
     "protobuf",
-    "accelerate>=1.13.0",
+    "accelerate>=1.13.0",  # required by the transcribe task's from_pretrained(device_map=...) path
     "pydantic>=2.0",
     "soundfile>=0.12",
     "soxr>=0.3",
 ]
 
 [project.optional-dependencies]
-vllm = [ "vllm>=0.19.1"]
+vllm = [ "vllm>=0.19.1,<0.22"]
 
 [project.urls]
 Repository = "https://github.com/princeton-ddss/tigerflow-ml"

--- a/uv.lock
+++ b/uv.lock
@@ -4765,11 +4765,11 @@ requires-dist = [
     { name = "sentencepiece" },
     { name = "soundfile", specifier = ">=0.12" },
     { name = "soxr", specifier = ">=0.3" },
-    { name = "tigerflow", specifier = ">=0.3.1" },
+    { name = "tigerflow", specifier = ">=0.3.1,<0.4" },
     { name = "timm" },
-    { name = "torch", specifier = ">=2.0" },
-    { name = "transformers", specifier = ">=4.51" },
-    { name = "vllm", marker = "extra == 'vllm'", specifier = ">=0.19.1" },
+    { name = "torch", specifier = ">=2.0,<3" },
+    { name = "transformers", specifier = ">=4.51,<6" },
+    { name = "vllm", marker = "extra == 'vllm'", specifier = ">=0.19.1,<0.22" },
 ]
 provides-extras = ["vllm"]
 


### PR DESCRIPTION
Closes #88. Closes #87.

## #88 — Upper bounds
Adds upper bounds to the dependencies whose major bumps or minor-version churn are likely to break us. tigerflow-ml installs into dedicated per-task environments, so library upper bounds don't cause the resolver collisions they would in a general-purpose library.

| Package | Bound | Rationale |
|---|---|---|
| `tigerflow` | `>=0.3.1,<0.4` | Unstabilized internal API surface |
| `vllm` | `>=0.19.1,<0.22` | Breaks between minors; cap tracks tested range |
| `transformers` | `>=4.51,<6` | Defensive major cap |
| `torch` | `>=2.0,<3` | Defensive major cap |

Left unbounded (stable, unlikely to break us): `Pillow`, `pymupdf`, `langdetect`, `opencv-python-headless`, `sentencepiece`, `protobuf`. All currently-locked versions fall within the new bounds; `uv lock` re-resolves cleanly.

Enables **Dependabot** (`.github/dependabot.yml`) for the `uv` ecosystem and GitHub Actions, so bumps arrive as CI-testable PRs. Documents the bound/bump policy in `CLAUDE.md`.

## #87 — Dependency audit
Audited `timm` and `accelerate`. **Both are real runtime dependencies and are kept:**
- **`timm`** — no source `import`, but DETR/RT-DETR backbones in the detect task (default `PekingU/rtdetr_r50vd`) load it at model-load time.
- **`accelerate`** — required by the transcribe task's `from_pretrained(..., device_map=device)` path ([transcriber.py:315](src/tigerflow_ml/audio/transcribe/transcriber.py#L315)). The issue's note that "all pipeline calls use plain device=" predates the transcribe rework.

Added explanatory comments in `pyproject.toml` so a future audit doesn't re-flag them.

## Verification
- `pre-commit run --all-files` ✅ (incl. check-yaml on dependabot.yml, ty)
- 227 unit tests pass ✅
- `uv lock` resolves within new bounds ✅

⚠️ Integration tests (real models on H100) recommended before merge to confirm the bounded resolution still loads each task's primary model.