### PR TITLE
ci: configure auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+# Configures GitHub's auto-generated release notes (the "Generate release notes"
+# button when drafting a release). PRs are grouped into the first category whose
+# label they match, so order matters and "*" must come last.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - breaking-change
+    - title: ✨ Features
+      labels:
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: ♻️ Refactors
+      labels:
+        - refactor
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧰 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds `.github/release.yml` so GitHub's **Generate release notes** button groups merged PRs by label.

## Categories
⚠️ Breaking Changes → ✨ Features → 🐛 Bug Fixes → ♻️ Refactors → 📚 Documentation → 🧰 Other Changes (catch-all). Bot authors (dependabot, github-actions) are excluded.

## Notes
- A `breaking-change` label + category is included for **future** CLI-breaking changes (post-1.0). Pre-1.0 / alpha→prod changes aren't breaking, so nothing is labeled breaking for v0.1.0.
- `tooling` / `tests` PRs fall into the 🧰 Other Changes catch-all by design.
- Created a `breaking-change` repo label to back the category.

Lands independently of the release; just needs to be on `main` before the v0.1.0 release is drafted.