### PR TITLE
fix(cd): bump version in-repo instead of pushing to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,15 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Configure Git credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v5
@@ -39,20 +33,16 @@ jobs:
             pyproject.toml
           python-version-file: ".python-version"
 
-      - name: Sync version with tag
+      # The version is bumped in-repo via PR before tagging (the release tag is
+      # cut from the bumped commit), so CD only verifies they agree — it never
+      # mutates pyproject.toml or pushes to main.
+      - name: Verify version matches tag
         run: |
           TAG_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
           PKG_VERSION=$(uv version --short)
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::warning::Syncing version: pyproject.toml has '$PKG_VERSION', updating to '$TAG_VERSION' from tag"
-            uv version "$TAG_VERSION"
-            if ! git diff --quiet pyproject.toml; then
-              git add pyproject.toml
-              git commit -m "Bump version to $TAG_VERSION"
-              git push origin HEAD:main
-              git tag -f "${{ github.event.release.tag_name }}"
-              git push origin "${{ github.event.release.tag_name }}" --force
-            fi
+            echo "::error::Tag is '$TAG_VERSION' but pyproject.toml is '$PKG_VERSION'. Bump the version in a PR and tag the merged commit."
+            exit 1
           fi
 
       - name: Build the package

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,12 @@ jobs:
       contents: read
       packages: write
     steps:
+      # On a release, build from the tagged commit so the image contents match
+      # the released version (the version bump is committed before tagging).
+      # For a manual smoke test (workflow_dispatch), ref is empty -> default branch.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tigerflow-ml"
-version = "0.1.0a1"
+version = "0.1.0"
 description = "ML task library for TigerFlow"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4707,7 +4707,7 @@ wheels = [
 
 [[package]]
 name = "tigerflow-ml"
-version = "0.1.0a1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
The v0.1.0 publish failed: CD's "Sync version with tag" step tries to `git push origin HEAD:main`, which the branch ruleset rejects (`GH013: Changes must be made through a pull request`). The same design also meant **Docker and PyPI built from un-bumped source** — `docker.yml` checks out the default branch (pre-bump), and the image was tagged `0.1.0` while internally carrying `0.1.0a1`.

## Fix
Move the version bump **into the repo**, before tagging:

- **`pyproject.toml`** bumped `0.1.0a1` → `0.1.0` here, in this PR.
- **`cd.yml`** — replace the commit-and-force-push "Sync version with tag" step with a **verify-only guard**: if the tag and `pyproject.toml` version disagree, fail loudly. No mutation, no push to main. Drops the now-unused git-credentials step and `contents: write` from the `publish` job (only `id-token: write` is needed for PyPI trusted publishing). Top-level `contents: write` stays — the `docs` job needs it for `mike --push`.
- **`docker.yml`** — `checkout` the release tag (`ref: github.event.release.tag_name`) so the image is built from the bumped commit. Manual `workflow_dispatch` runs still build the default branch.

## New release flow
1. Bump `pyproject.toml` in a PR (this one).
2. Merge.
3. Create the release / tag on the merged commit → CD verifies, builds, publishes; Docker builds the tagged commit.

## Verification
- `pre-commit run` ✅ (check-yaml on both workflows, ty)
- No PyPI artifact was published for the failed attempt — PyPI has only `0.1.0a0`/`0.1.0a1`, so re-releasing `0.1.0` is clean.

The previously-published v0.1.0 GitHub release + tag (pointing at the un-bumped commit) will be deleted and re-created on the merge of this PR.