### PR TITLE
ci: add uv lock check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,11 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+  - repo: local
+    hooks:
+      - id: uv-lock-check
+        name: uv lock --check
+        entry: uv lock --check
+        language: system
+        files: ^(pyproject\.toml|uv\.lock)$
+        pass_filenames: false


### PR DESCRIPTION
Adds a pre-commit check to run `uv lock --check` to ensure `pyproject.toml` and `uv.lock` are always synced. 

Closes #69 