### PR TITLE
feat: add structured output args for ocr and chat

### DIFF
--- a/docs/mkdocs/tasks/chat.md
+++ b/docs/mkdocs/tasks/chat.md
@@ -16,6 +16,7 @@ Analyze text or image files using vLLM compatible HuggingFace chat models.
 | `--max-model-len`     |                           | Maximum sequence length (input + output tokens) passed to vLLM. Set this for large-context models to avoid OOM. |
 | `--max-image-pixels`  |                           | Maximum image dimension in pixels (width or height). Larger images are downscaled while preserving aspect ratio. |
 | `--temperature`       | `0`                       | The model temperature. Lower numbers make models more deterministic |
+| `--response-schema`   |                           | Constrain the model's output format using vllm structured outputs. Format: `<type>=<value>`. Types: `choice` (list of strings), `json` (JSON schema dict), `regex` (regular expression), `grammar` (EBNF/GBNF grammar string). |
 | `--seed`              | `42`                      | The seed to set for more reproducible behavior                 |
 | `--llm-kwargs`        | `{}`                      | Additional kwargs for vLLM's LLM() constructor. Supplied values override task defaults. |
 | `--sampling-kwargs`   | `{}`                      | Additional kwargs for vLLM's SamplingParams() constructor. Supplied values override task defaults. |
@@ -144,4 +145,63 @@ Any HuggingFace model that is compatible with vLLM's `LLM.chat()`.
 
     ```text title="hummingbird.txt"
     "Nature's Symphony: A Hummingbird's Dance with a Lily"
+    ```
+
+### Structured outputs
+
+If you're using a model which supports [structured output](https://docs.vllm.ai/en/latest/features/structured_outputs/#offline-inference), you can provide one using `--response-schema`.
+
+=== "Choice"
+
+    ```yaml title="config.yaml"
+    tasks:
+        - name: chat
+            kind: slurm
+            module: tigerflow_ml.text.chat.slurm
+            input_ext: .txt
+            output_ext: .txt
+            max_workers: 1
+            worker_resources:
+                cpus: 1
+                gpus: 1
+                memory: 10G
+                time: 00:10:00
+                sbatch_options:
+                    - "--constraint=gpu80"
+            setup_commands:
+                - source ~/github/tigerflow-ml/.venv/bin/activate
+                - export VLLM_USE_FLASHINFER_SAMPLER=0
+            params:
+                model: Qwen/Qwen2.5-VL-7B-Instruct
+                cache-dir: ~/github/tigerflow-ml/.hf/hub/
+                prompt: 'What is the sentiment of this text?'
+                response_schema: choice=["Positive", "Negative]
+    ```
+
+=== "JSON"
+
+    ```yaml title="config.yaml"
+    tasks:
+        - name: chat
+            kind: slurm
+            module: tigerflow_ml.text.chat.slurm
+            input_ext: .jpeg
+            output_ext: .txt
+            max_workers: 1
+            worker_resources:
+                cpus: 1
+                gpus: 2
+                memory: 8G
+                time: 01:00:00
+                sbatch_options:
+                    - "--constraint=gpu80"
+            setup_commands:
+                - source ~/github/tigerflow-ml/.venv/bin/activate
+                - export VLLM_USE_FLASHINFER_SAMPLER=0
+            params:
+            model: Qwen/Qwen2.5-VL-32B-Instruct
+                cache-dir: ~/github/tigerflow-ml/.hf/hub/
+                prompt: What is in this image?
+                response_schema: 'json={"type":"object","properties":{"objects":{"type":"array","items":{"type":"string"}},"scene":{"type":"string"},"dominant_colors":{"type":"array","items":{"type":"string"}}},"required":["objects","scene"]}'
+                max-model-len: 4096
     ```

--- a/docs/mkdocs/tasks/chat.md
+++ b/docs/mkdocs/tasks/chat.md
@@ -175,7 +175,7 @@ If you're using a model which supports [structured output](https://docs.vllm.ai/
                 model: Qwen/Qwen2.5-VL-7B-Instruct
                 cache-dir: ~/github/tigerflow-ml/.hf/hub/
                 prompt: 'What is the sentiment of this text?'
-                response_schema: choice=["Positive", "Negative]
+                response_schema: choice=["Positive", "Negative"]
     ```
 
 === "JSON"
@@ -199,7 +199,7 @@ If you're using a model which supports [structured output](https://docs.vllm.ai/
                 - source ~/github/tigerflow-ml/.venv/bin/activate
                 - export VLLM_USE_FLASHINFER_SAMPLER=0
             params:
-            model: Qwen/Qwen2.5-VL-32B-Instruct
+                model: Qwen/Qwen2.5-VL-32B-Instruct
                 cache-dir: ~/github/tigerflow-ml/.hf/hub/
                 prompt: What is in this image?
                 response_schema: 'json={"type":"object","properties":{"objects":{"type":"array","items":{"type":"string"}},"scene":{"type":"string"},"dominant_colors":{"type":"array","items":{"type":"string"}}},"required":["objects","scene"]}'

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -18,6 +18,7 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 | `--sampling-kwargs` | `{}`                        | Additional kwargs for vLLM's SamplingParams() constructor. Supplied values override task defaults. |
 | `--chat-kwargs`   | `{}`                          | Additional kwargs for vLLM's LLM.chat(). Supplied values override task defaults.                   |
 | `--prompt`        |                               | Prompt for image-text-to-text models                                                               |
+| `--json-schema`   |                               | Constrain the model's output to a JSON schema using vllm structured outputs. Provide the schema as a JSON string, e.g. `{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}`. Requires a model that supports structured outputs. |
 
 
 

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -200,7 +200,7 @@ tasks:
     output_ext: .txt
     max_workers: 4
     worker_resources:
-      cpus: 2
+      cpus: 1
       gpus: 1
       memory: 16G
       time: 04:00:00
@@ -208,4 +208,29 @@ tasks:
       model: stepfun-ai/GOT-OCR-2.0-hf
       prompt: "Extract all text from this image"
       cache_dir: ~/path/to/model/hub/
+```
+
+### Structured JSON output
+
+If you're using a model which supports [structured output](https://docs.vllm.ai/en/latest/features/structured_outputs/#offline-inference), you can provide a structured json output schema using `--json-schema`
+
+```yaml title="config.yaml"
+tasks:
+  - name: ocr
+    kind: slurm
+    module: tigerflow_ml.text.ocr.slurm
+    input_ext: .pdf
+    output_ext: .txt
+    max_workers: 4
+    worker_resources:
+      cpus: 1
+      gpus: 2
+      memory: 16G
+      time: 04:00:00
+    params:
+      model: Qwen/Qwen2.5-VL-32B-Instruct
+      prompt: "Extract all text from this image in valid json format"
+      cache_dir: ~/path/to/model/hub/
+      max-model-len: 4096
+      json-schema: '{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}'
 ```

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -118,6 +118,8 @@ class _ChatBase:
             "max_tokens": context.max_tokens,
         }
         if context.response_schema is not None:
+            from tigerflow_ml.utils import SchemaType
+
             schema_type, sep, schema_value = context.response_schema.partition("=")
             if not sep:
                 raise ValueError(
@@ -126,7 +128,7 @@ class _ChatBase:
                     " grammar"
                 )
             sampling_kwargs["structured_outputs"] = process_response_schema(
-                schema_type.strip(), schema_value.strip()
+                SchemaType(schema_type.strip()), schema_value.strip()
             )
 
         sampling_kwargs.update(user_sampling_kwargs)

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -10,7 +10,11 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
-from tigerflow_ml.utils import parse_kwargs, read_text_file_strict
+from tigerflow_ml.utils import (
+    parse_kwargs,
+    process_response_schema,
+    read_text_file_strict,
+)
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _IMG_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp"]
@@ -46,6 +50,21 @@ class _ChatBase:
                 max=2.0,
             ),
         ] = 0.0
+
+        response_schema: Annotated[
+            str | None,
+            typer.Option(
+                help=(
+                    "Constrain the model's output format using vllm structured outputs."
+                    " Format: '<type>=<value>'. "
+                    "Types: "
+                    'choice (list of strings, e.g. choice=["Yes","No"]), '
+                    'json (JSON schema dict, e.g. json={"type":"object",...}), '
+                    "regex (regular expression, e.g. regex=[0-9]+), "
+                    "grammar (EBNF/GBNF grammar string)."
+                )
+            ),
+        ] = None
 
     @staticmethod
     def setup(context: SetupContext):
@@ -98,6 +117,18 @@ class _ChatBase:
             "seed": context.seed,
             "max_tokens": context.max_tokens,
         }
+        if context.response_schema is not None:
+            schema_type, sep, schema_value = context.response_schema.partition("=")
+            if not sep:
+                raise ValueError(
+                    f"--response-schema must be in the form '<type>=<value>', got: "
+                    f"{context.response_schema!r}. Valid types: choice, json, regex,"
+                    " grammar"
+                )
+            sampling_kwargs["structured_outputs"] = process_response_schema(
+                schema_type.strip(), schema_value.strip()
+            )
+
         sampling_kwargs.update(user_sampling_kwargs)
         logger.info(f"    sampling_kwargs={sampling_kwargs}")
 

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -106,8 +106,10 @@ class _OCRBase:
             "max_tokens": context.max_tokens,
         }
         if context.json_schema is not None:
+            from tigerflow_ml.utils import SchemaType
+
             sampling_kwargs["structured_outputs"] = process_response_schema(
-                "json", context.json_schema
+                SchemaType.JSON, context.json_schema
             )
         sampling_kwargs.update(user_sampling_kwargs)
         logger.info(f"   sampling_kwargs={sampling_kwargs}")

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -15,7 +15,12 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
-from tigerflow_ml.utils import load_images, parse_kwargs, strip_markdown_from_json
+from tigerflow_ml.utils import (
+    load_images,
+    parse_kwargs,
+    process_response_schema,
+    strip_markdown_from_json,
+)
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -42,6 +47,19 @@ class _OCRBase:
             int,
             typer.Option(help="Maximum number of tokens to generate per image"),
         ] = 4096
+
+        json_schema: Annotated[
+            str | None,
+            typer.Option(
+                help=(
+                    "Constrain the model's output to a JSON schema using vllm "
+                    "structured outputs. Provide the schema as a JSON string, e.g. "
+                    '\'{"type":"object","properties":{"text":{"type":"string"}},"required"'
+                    ':["text"]}\'. '
+                    "Requires a model that supports structured outputs."
+                )
+            ),
+        ] = None
 
     @staticmethod
     def setup(context: SetupContext):
@@ -87,6 +105,10 @@ class _OCRBase:
             "seed": context.seed,
             "max_tokens": context.max_tokens,
         }
+        if context.json_schema is not None:
+            sampling_kwargs["structured_outputs"] = process_response_schema(
+                "json", context.json_schema
+            )
         sampling_kwargs.update(user_sampling_kwargs)
         logger.info(f"   sampling_kwargs={sampling_kwargs}")
 

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -175,6 +175,53 @@ def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:
         raise ValueError(f"--{name} is not a valid dict: {value!r}") from e
 
 
+def process_response_schema(schema_type: str, schema_value: str):
+    """
+    Build a vllm StructuredOutputsParams from an explicit type and value string.
+
+    Args:
+        schema_type: One of "choice", "json", "regex", "grammar".
+        schema_value: The schema value as a string. For "choice", a list;
+            for "json", a JSON object; for "regex"/"grammar", a raw string.
+    """
+    from vllm.sampling_params import StructuredOutputsParams
+
+    if schema_type == "choice":
+        try:
+            value = json.loads(schema_value)
+        except json.JSONDecodeError:
+            try:
+                value = ast.literal_eval(schema_value)
+            except (ValueError, SyntaxError) as e:
+                raise ValueError(
+                    "--response-schema choice value is not a valid list: "
+                    f"{schema_value!r}"
+                ) from e
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise ValueError(
+                "--response-schema choice value must be a list of strings,"
+                f" got: {value!r}"
+            )
+        return StructuredOutputsParams(choice=value)
+    elif schema_type == "json":
+        try:
+            value = json.loads(schema_value)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"--response-schema json value is not valid JSON: {schema_value!r}"
+            ) from e
+        return StructuredOutputsParams(json=value)
+    elif schema_type == "regex":
+        return StructuredOutputsParams(regex=schema_value)
+    elif schema_type == "grammar":
+        return StructuredOutputsParams(grammar=schema_value)
+    else:
+        raise ValueError(
+            f"--response-schema type {schema_type!r} is not supported. "
+            "Valid types: choice, json, regex, grammar"
+        )
+
+
 def get_model_config(
     model: str,
     allow_fetch: bool = False,

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -184,8 +184,6 @@ def process_response_schema(schema_type: str, schema_value: str):
         schema_value: The schema value as a string. For "choice", a list;
             for "json", a JSON object; for "regex"/"grammar", a raw string.
     """
-    from vllm.sampling_params import StructuredOutputsParams  # type: ignore
-
     if schema_type == "choice":
         try:
             value = json.loads(schema_value)
@@ -202,6 +200,8 @@ def process_response_schema(schema_type: str, schema_value: str):
                 "--response-schema choice value must be a list of strings,"
                 f" got: {value!r}"
             )
+        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
+
         return StructuredOutputsParams(choice=value)
     elif schema_type == "json":
         try:
@@ -210,10 +210,16 @@ def process_response_schema(schema_type: str, schema_value: str):
             raise ValueError(
                 f"--response-schema json value is not valid JSON: {schema_value!r}"
             ) from e
+        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
+
         return StructuredOutputsParams(json=value)
     elif schema_type == "regex":
+        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
+
         return StructuredOutputsParams(regex=schema_value)
     elif schema_type == "grammar":
+        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
+
         return StructuredOutputsParams(grammar=schema_value)
     else:
         raise ValueError(

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -184,7 +184,7 @@ def process_response_schema(schema_type: str, schema_value: str):
         schema_value: The schema value as a string. For "choice", a list;
             for "json", a JSON object; for "regex"/"grammar", a raw string.
     """
-    from vllm.sampling_params import StructuredOutputsParams
+    from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
     if schema_type == "choice":
         try:

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -2,6 +2,7 @@
 
 import ast
 import json
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -175,7 +176,16 @@ def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:
         raise ValueError(f"--{name} is not a valid dict: {value!r}") from e
 
 
-def process_response_schema(schema_type: str, schema_value: str):
+class SchemaType(str, Enum):
+    """Schema type for vllm structured response"""
+
+    JSON = "json"
+    CHOICE = "choice"
+    REGEX = "regex"
+    GRAMMAR = "grammar"
+
+
+def process_response_schema(schema_type: SchemaType, schema_value: str):
     """
     Build a vllm StructuredOutputsParams from an explicit type and value string.
 
@@ -184,7 +194,7 @@ def process_response_schema(schema_type: str, schema_value: str):
         schema_value: The schema value as a string. For "choice", a list;
             for "json", a JSON object; for "regex"/"grammar", a raw string.
     """
-    if schema_type == "choice":
+    if schema_type == SchemaType.CHOICE:
         try:
             value = json.loads(schema_value)
         except json.JSONDecodeError:
@@ -203,7 +213,7 @@ def process_response_schema(schema_type: str, schema_value: str):
         from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
         return StructuredOutputsParams(choice=value)
-    elif schema_type == "json":
+    elif schema_type == SchemaType.JSON:
         try:
             value = json.loads(schema_value)
         except json.JSONDecodeError as e:
@@ -213,19 +223,14 @@ def process_response_schema(schema_type: str, schema_value: str):
         from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
         return StructuredOutputsParams(json=value)
-    elif schema_type == "regex":
+    elif schema_type == SchemaType.REGEX:
         from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
         return StructuredOutputsParams(regex=schema_value)
-    elif schema_type == "grammar":
+    elif schema_type == SchemaType.GRAMMAR:
         from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
         return StructuredOutputsParams(grammar=schema_value)
-    else:
-        raise ValueError(
-            f"--response-schema type {schema_type!r} is not supported. "
-            "Valid types: choice, json, regex, grammar"
-        )
 
 
 def get_model_config(

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -11,6 +11,7 @@ from tigerflow.logconfig import logger
 if TYPE_CHECKING:
     from PIL import Image
     from transformers import PretrainedConfig, PreTrainedTokenizerBase
+    from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
 
 class EmptyFileError(Exception):
@@ -185,7 +186,9 @@ class SchemaType(str, Enum):
     GRAMMAR = "grammar"
 
 
-def process_response_schema(schema_type: SchemaType, schema_value: str):
+def process_response_schema(
+    schema_type: SchemaType, schema_value: str
+) -> "StructuredOutputsParams":
     """
     Build a vllm StructuredOutputsParams from an explicit type and value string.
 
@@ -194,6 +197,8 @@ def process_response_schema(schema_type: SchemaType, schema_value: str):
         schema_value: The schema value as a string. For "choice", a list;
             for "json", a JSON object; for "regex"/"grammar", a raw string.
     """
+    from vllm.sampling_params import StructuredOutputsParams  # type: ignore
+
     if schema_type == SchemaType.CHOICE:
         try:
             value = json.loads(schema_value)
@@ -210,7 +215,6 @@ def process_response_schema(schema_type: SchemaType, schema_value: str):
                 "--response-schema choice value must be a list of strings,"
                 f" got: {value!r}"
             )
-        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
         return StructuredOutputsParams(choice=value)
     elif schema_type == SchemaType.JSON:
@@ -220,16 +224,11 @@ def process_response_schema(schema_type: SchemaType, schema_value: str):
             raise ValueError(
                 f"--response-schema json value is not valid JSON: {schema_value!r}"
             ) from e
-        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
         return StructuredOutputsParams(json=value)
     elif schema_type == SchemaType.REGEX:
-        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
-
         return StructuredOutputsParams(regex=schema_value)
     elif schema_type == SchemaType.GRAMMAR:
-        from vllm.sampling_params import StructuredOutputsParams  # type: ignore
-
         return StructuredOutputsParams(grammar=schema_value)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -339,14 +339,17 @@ class TestProcessResponseSchema:
         mock_cls.assert_called_once_with(grammar=grammar)
 
     def test_choice_invalid_value_raises(self):
+        pytest.importorskip("vllm")
         with pytest.raises(ValueError, match="not a valid list"):
             process_response_schema(SchemaType.CHOICE, "not a list")
 
     def test_choice_non_string_elements_raises(self):
+        pytest.importorskip("vllm")
         with pytest.raises(ValueError, match="list of strings"):
             process_response_schema(SchemaType.CHOICE, "[1, 2, 3]")
 
     def test_json_invalid_raises(self):
+        pytest.importorskip("vllm")
         with pytest.raises(ValueError, match="not valid JSON"):
             process_response_schema(SchemaType.JSON, "{bad json}")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -273,7 +273,7 @@ class TestLoadImages:
         for ext in _IMG_EXTENSIONS:
             file = "test" + ext
             if ext in (".heic", ".heif"):
-                path = _make_heic_file(tmp_path / file)
+                continue
             else:
                 path = _make_image_file(tmp_path / file)
             images = load_images(path)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,6 +9,7 @@ from tigerflow_ml.utils import (
     ENCODING_FALLBACK_CHAIN,
     EmptyFileError,
     ModelConfigParsingError,
+    SchemaType,
     get_model_config,
     get_model_context_window,
     get_tokenizer,
@@ -314,44 +315,40 @@ class TestProcessResponseSchema:
         return mock_cls
 
     def test_choice_json_list(self):
-        mock_cls = self._call("choice", '["Yes", "No"]')
+        mock_cls = self._call(SchemaType.CHOICE, '["Yes", "No"]')
         mock_cls.assert_called_once_with(choice=["Yes", "No"])
 
     def test_choice_python_list_syntax(self):
-        mock_cls = self._call("choice", "['A', 'B', 'C']")
+        mock_cls = self._call(SchemaType.CHOICE, "['A', 'B', 'C']")
         mock_cls.assert_called_once_with(choice=["A", "B", "C"])
 
     def test_json_schema_dict(self):
         schema = '{"type": "object", "properties": {"label": {"type": "string"}}}'
-        mock_cls = self._call("json", schema)
+        mock_cls = self._call(SchemaType.JSON, schema)
         mock_cls.assert_called_once_with(
             json={"type": "object", "properties": {"label": {"type": "string"}}}
         )
 
     def test_regex_passes_raw_string(self):
-        mock_cls = self._call("regex", "[0-9]+")
+        mock_cls = self._call(SchemaType.REGEX, "[0-9]+")
         mock_cls.assert_called_once_with(regex="[0-9]+")
 
     def test_grammar_passes_raw_string(self):
         grammar = 'root ::= "yes" | "no"'
-        mock_cls = self._call("grammar", grammar)
+        mock_cls = self._call(SchemaType.GRAMMAR, grammar)
         mock_cls.assert_called_once_with(grammar=grammar)
 
     def test_choice_invalid_value_raises(self):
         with pytest.raises(ValueError, match="not a valid list"):
-            process_response_schema("choice", "not a list")
+            process_response_schema(SchemaType.CHOICE, "not a list")
 
     def test_choice_non_string_elements_raises(self):
         with pytest.raises(ValueError, match="list of strings"):
-            process_response_schema("choice", "[1, 2, 3]")
+            process_response_schema(SchemaType.CHOICE, "[1, 2, 3]")
 
     def test_json_invalid_raises(self):
         with pytest.raises(ValueError, match="not valid JSON"):
-            process_response_schema("json", "{bad json}")
-
-    def test_unknown_type_raises(self):
-        with pytest.raises(ValueError, match="not supported"):
-            process_response_schema("structured", "value")
+            process_response_schema(SchemaType.JSON, "{bad json}")
 
 
 class TestGetModelContextWindow:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -308,6 +308,7 @@ class TestStripMarkdownFromJson:
 
 class TestProcessResponseSchema:
     def _call(self, schema_type, schema_value):
+        pytest.importorskip("vllm")
         with patch("vllm.sampling_params.StructuredOutputsParams") as mock_cls:
             process_response_schema(schema_type, schema_value)
         return mock_cls

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,6 +13,7 @@ from tigerflow_ml.utils import (
     get_model_context_window,
     get_tokenizer,
     load_images,
+    process_response_schema,
     read_text_file_strict,
     read_text_file_with_fallback,
     strip_markdown_from_json,
@@ -303,6 +304,53 @@ class TestStripMarkdownFromJson:
     def test_no_language_tag_with_array(self):
         result = strip_markdown_from_json("```\n[1, 2, 3]\n```")
         assert result == "[1, 2, 3]"
+
+
+class TestProcessResponseSchema:
+    def _call(self, schema_type, schema_value):
+        with patch("vllm.sampling_params.StructuredOutputsParams") as mock_cls:
+            process_response_schema(schema_type, schema_value)
+        return mock_cls
+
+    def test_choice_json_list(self):
+        mock_cls = self._call("choice", '["Yes", "No"]')
+        mock_cls.assert_called_once_with(choice=["Yes", "No"])
+
+    def test_choice_python_list_syntax(self):
+        mock_cls = self._call("choice", "['A', 'B', 'C']")
+        mock_cls.assert_called_once_with(choice=["A", "B", "C"])
+
+    def test_json_schema_dict(self):
+        schema = '{"type": "object", "properties": {"label": {"type": "string"}}}'
+        mock_cls = self._call("json", schema)
+        mock_cls.assert_called_once_with(
+            json={"type": "object", "properties": {"label": {"type": "string"}}}
+        )
+
+    def test_regex_passes_raw_string(self):
+        mock_cls = self._call("regex", "[0-9]+")
+        mock_cls.assert_called_once_with(regex="[0-9]+")
+
+    def test_grammar_passes_raw_string(self):
+        grammar = 'root ::= "yes" | "no"'
+        mock_cls = self._call("grammar", grammar)
+        mock_cls.assert_called_once_with(grammar=grammar)
+
+    def test_choice_invalid_value_raises(self):
+        with pytest.raises(ValueError, match="not a valid list"):
+            process_response_schema("choice", "not a list")
+
+    def test_choice_non_string_elements_raises(self):
+        with pytest.raises(ValueError, match="list of strings"):
+            process_response_schema("choice", "[1, 2, 3]")
+
+    def test_json_invalid_raises(self):
+        with pytest.raises(ValueError, match="not valid JSON"):
+            process_response_schema("json", "{bad json}")
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="not supported"):
+            process_response_schema("structured", "value")
 
 
 class TestGetModelContextWindow:

--- a/tests/unit/text/chat/test_params.py
+++ b/tests/unit/text/chat/test_params.py
@@ -5,3 +5,4 @@ def test_chat_defaults():
     p = _ChatBase.Params()
     assert p.max_image_pixels is None
     assert p.temperature == 0.0
+    assert p.response_schema is None

--- a/tests/unit/text/ocr/test_params.py
+++ b/tests/unit/text/ocr/test_params.py
@@ -4,3 +4,4 @@ from tigerflow_ml.text.ocr._base import _OCRBase
 def test_ocr_defaults():
     p = _OCRBase.Params()
     assert p.max_tokens == 4096
+    assert p.json_schema is None


### PR DESCRIPTION
- adds `process_response_schema()` to the shared utils 
- adds support for a `--resonse-schema` arg for the chat task
- adds support for a `--json-schema` arg for the ocr task
- updates tests and documentation

Closes #161 
Ref #55 