### PR TITLE
refactor: chat now uses shared load_images()

### DIFF
--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -11,13 +11,14 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
+    IMG_EXTENSIONS,
+    load_images,
     parse_kwargs,
     process_response_schema,
     read_text_file_strict,
 )
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
-_IMG_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp"]
 
 
 class _ChatBase:
@@ -149,7 +150,12 @@ class _ChatBase:
 
         if input_file.suffix.lower() in _TEXT_EXTENSIONS:
             result = _ChatBase._process_text_file(context, input_file)
-        elif input_file.suffix.lower() in _IMG_EXTENSIONS:
+        elif input_file.suffix.lower() in IMG_EXTENSIONS:
+            if input_file.suffix.lower() == ".pdf":
+                raise ValueError(
+                    f"File extension {input_file.suffix} not currently supported - "
+                    "raise an issue on Github"
+                )
             result = _ChatBase._process_img_file(context, input_file)
         else:
             raise ValueError(
@@ -175,7 +181,7 @@ class _ChatBase:
     def _process_img_file(context: SetupContext, input_file: Path) -> str:
         import PIL.Image
 
-        image = PIL.Image.open(input_file).convert("RGB")
+        image = load_images(path=input_file)[0]
 
         if context.max_image_pixels is not None:
             original_size = image.size

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -92,7 +92,7 @@ def read_text_file_strict(path: Path) -> str:
     return content
 
 
-_IMG_EXTENSIONS = [
+IMG_EXTENSIONS = [
     ".jpg",
     ".jpeg",
     ".png",
@@ -121,10 +121,10 @@ def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"
     """
     from PIL import Image
 
-    if path.suffix.lower() not in _IMG_EXTENSIONS:
+    if path.suffix.lower() not in IMG_EXTENSIONS:
         raise ValueError(
             f"{path.suffix} is not a valid file type -- please choose "
-            f"one of: {_IMG_EXTENSIONS}"
+            f"one of: {IMG_EXTENSIONS}"
         )
     if path.suffix.lower() == ".heic" or path.suffix.lower() == ".heif":
         from pillow_heif import register_heif_opener

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -268,9 +268,9 @@ class TestLoadImages:
         assert images[0].mode == "RGB"
 
     def test_only_supports_img_and_pdf_extensions(self, tmp_path):
-        from tigerflow_ml.utils import _IMG_EXTENSIONS
+        from tigerflow_ml.utils import IMG_EXTENSIONS
 
-        for ext in _IMG_EXTENSIONS:
+        for ext in IMG_EXTENSIONS:
             file = "test" + ext
             if ext in (".heic", ".heif"):
                 continue


### PR DESCRIPTION
Refactors the `chat` task to use the `load_images()` helper from the shared utils. Though `load_images()` supports `.pdf`, the `chat` task explicitly rejects `.pdfs` -- this could easily be changed if processing pdfs on a page-by-page image is ideal. 