### PR TITLE
feat(chat): add video and audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install tigerflow-ml[vllm]
 |------------------|---------------------------------------|-----------------------------------|
 | OCR              | Extract text from images and PDFs     | `ocr` / `ocr-local`               |
 | Translation      | Translate text documents              | `translate` / `translate-local`   |
-| Chat             | Apply a chat prompt to images or text | `chat` / `chat-local`             |
+| Chat             | Apply a chat prompt to text, images, audio, or video | `chat` / `chat-local`             |
 | Transcription    | Transcribe audio to text              | `transcribe` / `transcribe-local` |
 | Object Detection | Detect objects in images and videos   | `detect` / `detect-local`         |
 

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -39,7 +39,7 @@ hide:
 - [Translation](tasks/translate.md) — Translate text documents
 - [Transcription](tasks/transcribe.md) — Transcribe audio to text
 - [Object Detection](tasks/detect.md) — Detect objects in images and videos
-- [Chat](tasks/chat.md) - Apply a chat prompt to text or image documents
+- [Chat](tasks/chat.md) - Apply a chat prompt to text, image, audio, or video documents
 
 ## Installation
 

--- a/docs/mkdocs/tasks/chat.md
+++ b/docs/mkdocs/tasks/chat.md
@@ -16,7 +16,7 @@ Analyze text, image, audio, or video files using vLLM compatible HuggingFace cha
 | `--max-model-len`     |                           | Maximum sequence length (input + output tokens) passed to vLLM. Set this for large-context models to avoid OOM. |
 | `--max-image-pixels`  |                           | Maximum image dimension in pixels (width or height). Larger images are downscaled while preserving aspect ratio. |
 | `--audio-sampling-rate` | `16000`                 | Sampling rate (Hz) audio inputs are resampled to before being sent to the model. |
-| `--video-sample-fps`  |                           | Frame rate (fps) video inputs are resampled to before being sent to the model. Frames are dropped to hit this rate; the resampled video has no audio track. Defaults to no resampling. |
+| `--video-sample-fps`  |                           | Frame rate (fps) video inputs are resampled to before being sent to the model. Frames are dropped to hit this rate. Defaults to no resampling. |
 | `--temperature`       | `0`                       | The model temperature. Lower numbers make models more deterministic |
 | `--response-schema`   |                           | Constrain the model's output format using vllm structured outputs. Format: `<type>=<value>`. Types: `choice` (list of strings), `json` (JSON schema dict), `regex` (regular expression), `grammar` (EBNF/GBNF grammar string). |
 | `--seed`              | `42`                      | The seed to set for more reproducible behavior                 |
@@ -27,7 +27,7 @@ Analyze text, image, audio, or video files using vLLM compatible HuggingFace cha
 
 ## Supported Input Formats
 
-Text files, images, audio, and video files are supported (depends on the `--model` being compatible with vLLM's `image_url`/`audio_url`/`video_url` chat content types)
+Text files, images, audio, and video files are supported (depends on the `--model` being compatible with vLLM's `image_pil`/`audio_url`/`video_url` chat content types)
 
 ## Output Format
 

--- a/docs/mkdocs/tasks/chat.md
+++ b/docs/mkdocs/tasks/chat.md
@@ -1,6 +1,6 @@
 # Chat
 
-Analyze text or image files using vLLM compatible HuggingFace chat models.
+Analyze text, image, audio, or video files using vLLM compatible HuggingFace chat models.
 
 ## Parameters
 
@@ -15,6 +15,8 @@ Analyze text or image files using vLLM compatible HuggingFace chat models.
 | `--allow-fetch`       | `--no-allow-fetch`        | Allow downloads from HuggingFace Hub (network access required) |
 | `--max-model-len`     |                           | Maximum sequence length (input + output tokens) passed to vLLM. Set this for large-context models to avoid OOM. |
 | `--max-image-pixels`  |                           | Maximum image dimension in pixels (width or height). Larger images are downscaled while preserving aspect ratio. |
+| `--audio-sampling-rate` | `16000`                 | Sampling rate (Hz) audio inputs are resampled to before being sent to the model. |
+| `--video-sample-fps`  |                           | Frame rate (fps) video inputs are resampled to before being sent to the model. Frames are dropped to hit this rate; the resampled video has no audio track. Defaults to no resampling. |
 | `--temperature`       | `0`                       | The model temperature. Lower numbers make models more deterministic |
 | `--response-schema`   |                           | Constrain the model's output format using vllm structured outputs. Format: `<type>=<value>`. Types: `choice` (list of strings), `json` (JSON schema dict), `regex` (regular expression), `grammar` (EBNF/GBNF grammar string). |
 | `--seed`              | `42`                      | The seed to set for more reproducible behavior                 |
@@ -25,7 +27,7 @@ Analyze text or image files using vLLM compatible HuggingFace chat models.
 
 ## Supported Input Formats
 
-Text files (.txt, .text, .md, .log, .rtf) and images (.jpg, .jpeg, .png, .tiff, .tif, .bmp)
+Text files, images, audio, and video files are supported (depends on the `--model` being compatible with vLLM's `image_url`/`audio_url`/`video_url` chat content types)
 
 ## Output Format
 

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -15,6 +15,7 @@ from tigerflow_ml.utils import (
     IMG_EXTENSIONS,
     load_audio,
     load_images,
+    load_video,
     parse_kwargs,
     process_response_schema,
     read_text_file_strict,
@@ -22,6 +23,7 @@ from tigerflow_ml.utils import (
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _AUDIO_EXTENSIONS = [".wav", ".flac", ".ogg", ".aiff", ".aif", ".mp3"]
+_VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"]
 
 
 class _ChatBase:
@@ -170,6 +172,8 @@ class _ChatBase:
             result = _ChatBase._process_img_file(context, input_file)
         elif input_file.suffix.lower() in _AUDIO_EXTENSIONS:
             result = _ChatBase._process_audio_file(context, input_file)
+        elif input_file.suffix.lower() in _VIDEO_EXTENSIONS:
+            result = _ChatBase._process_video_file(context, input_file)
         else:
             raise ValueError(
                 f"File extension {input_file.suffix} not currently supported - "
@@ -222,6 +226,16 @@ class _ChatBase:
             prompt=context.prompt,
             audio_data=audio_data,
             sampling_rate=context.audio_sampling_rate,
+            system_message=context.system_message,
+        )
+        return _run_chat(context, message)
+
+    @staticmethod
+    def _process_video_file(context: SetupContext, input_file: Path) -> str:
+        video_bytes = load_video(input_file)
+        message = _build_video_message(
+            prompt=context.prompt,
+            video_bytes=video_bytes,
             system_message=context.system_message,
         )
         return _run_chat(context, message)
@@ -336,6 +350,26 @@ def _build_audio_message(
 
     user_content: list[dict[str, Any]] = [
         {"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{b64}"}},
+        {"type": "text", "text": prompt},
+    ]
+
+    if system_message:
+        return [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_content},
+        ]
+    return [{"role": "user", "content": user_content}]
+
+
+def _build_video_message(
+    prompt: str, video_bytes: bytes, system_message: str | None
+) -> list[dict[str, Any]]:
+    import base64
+
+    b64 = base64.b64encode(video_bytes).decode("utf-8")
+
+    user_content: list[dict[str, Any]] = [
+        {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{b64}"}},
         {"type": "text", "text": prompt},
     ]
 

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -55,6 +55,15 @@ class _ChatBase:
             ),
         ] = 16000
 
+        video_sample_fps: Annotated[
+            float | None,
+            typer.Option(
+                help="Frame rate (fps) video inputs are resampled to before "
+                "being sent to the model. Frames are dropped to hit this rate. "
+                "Defaults to None (no resampling)."
+            ),
+        ] = None
+
         temperature: Annotated[
             float,
             typer.Option(
@@ -232,7 +241,7 @@ class _ChatBase:
 
     @staticmethod
     def _process_video_file(context: SetupContext, input_file: Path) -> str:
-        video_bytes = load_video(input_file)
+        video_bytes = load_video(input_file, sample_fps=context.video_sample_fps)
         message = _build_video_message(
             prompt=context.prompt,
             video_bytes=video_bytes,

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -207,7 +207,7 @@ class _ChatBase:
     def _process_img_file(context: SetupContext, input_file: Path) -> str:
         import PIL.Image
 
-        image = load_images(path=input_file)[0]
+        image = next(load_images(path=input_file, max_images=1))
 
         if context.max_image_pixels is not None:
             original_size = image.size

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -5,6 +5,7 @@ Apply a chat prompt to input texts using Hugging Face models.
 from pathlib import Path
 from typing import Annotated, Any
 
+import numpy as np
 import typer
 from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
@@ -12,6 +13,7 @@ from tigerflow.utils import SetupContext
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
     IMG_EXTENSIONS,
+    load_audio,
     load_images,
     parse_kwargs,
     process_response_schema,
@@ -19,6 +21,7 @@ from tigerflow_ml.utils import (
 )
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
+_AUDIO_EXTENSIONS = [".wav", ".flac", ".ogg", ".aiff", ".aif", ".mp3"]
 
 
 class _ChatBase:
@@ -41,6 +44,14 @@ class _ChatBase:
                 "Larger images are downscaled while preserving aspect ratio."
             ),
         ] = None
+
+        audio_sampling_rate: Annotated[
+            int,
+            typer.Option(
+                help="Sampling rate (Hz) audio inputs are resampled to before "
+                "being sent to the model."
+            ),
+        ] = 16000
 
         temperature: Annotated[
             float,
@@ -157,6 +168,8 @@ class _ChatBase:
                     "raise an issue on Github"
                 )
             result = _ChatBase._process_img_file(context, input_file)
+        elif input_file.suffix.lower() in _AUDIO_EXTENSIONS:
+            result = _ChatBase._process_audio_file(context, input_file)
         else:
             raise ValueError(
                 f"File extension {input_file.suffix} not currently supported - "
@@ -198,6 +211,17 @@ class _ChatBase:
         message = _build_img_message(
             prompt=context.prompt,
             image=image,
+            system_message=context.system_message,
+        )
+        return _run_chat(context, message)
+
+    @staticmethod
+    def _process_audio_file(context: SetupContext, input_file: Path) -> str:
+        audio_data = load_audio(input_file, sampling_rate=context.audio_sampling_rate)
+        message = _build_audio_message(
+            prompt=context.prompt,
+            audio_data=audio_data,
+            sampling_rate=context.audio_sampling_rate,
             system_message=context.system_message,
         )
         return _run_chat(context, message)
@@ -287,6 +311,31 @@ def _build_img_message(
 
     user_content: list[dict[str, Any]] = [
         {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+        {"type": "text", "text": prompt},
+    ]
+
+    if system_message:
+        return [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_content},
+        ]
+    return [{"role": "user", "content": user_content}]
+
+
+def _build_audio_message(
+    prompt: str, audio_data: np.ndarray, sampling_rate: int, system_message: str | None
+) -> list[dict[str, Any]]:
+    import base64
+    import io
+
+    import soundfile as sf
+
+    buf = io.BytesIO()
+    sf.write(buf, audio_data, sampling_rate, format="WAV")
+    b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+    user_content: list[dict[str, Any]] = [
+        {"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{b64}"}},
         {"type": "text", "text": prompt},
     ]
 

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -325,15 +325,8 @@ def _build_txt_message(
 def _build_img_message(
     prompt: str, image, system_message: str | None
 ) -> list[dict[str, Any]]:
-    import base64
-    import io
-
-    buf = io.BytesIO()
-    image.save(buf, format="PNG")
-    b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
-
     user_content: list[dict[str, Any]] = [
-        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+        {"type": "image_pil", "image_pil": image},
         {"type": "text", "text": prompt},
     ]
 

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -60,7 +60,7 @@ class _ChatBase:
             typer.Option(
                 help="Frame rate (fps) video inputs are resampled to before "
                 "being sent to the model. Frames are dropped to hit this rate. "
-                "Defaults to None (no resampling)."
+                "Defaults to None (no resampling).",
             ),
         ] = None
 

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -7,6 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
 from tigerflow.logconfig import logger
 
 if TYPE_CHECKING:
@@ -188,6 +189,30 @@ def batched(iterable: Iterator, n: int) -> Iterator[list]:
             batch = []
     if batch:
         yield batch
+
+
+def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
+    """Load an audio file as a mono float32 array at the given sampling rate.
+
+    Decodes with ``soundfile``, averages channels to mono, and resamples with
+    ``soxr`` if needed.
+
+    Args:
+        input_file: Path to the audio file.
+        sampling_rate: Target sampling rate in Hz.
+
+    Returns:
+        A 1-D float32 array of samples at ``sampling_rate``.
+    """
+    import soundfile as sf
+    import soxr
+
+    array, sr = sf.read(str(input_file), dtype="float32", always_2d=False)
+    if array.ndim > 1:
+        array = array.mean(axis=1)
+    if sr != sampling_rate:
+        array = soxr.resample(array, sr, sampling_rate)
+    return np.ascontiguousarray(array, dtype=np.float32)
 
 
 def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -216,14 +216,59 @@ def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
 
 
 def load_video(input_file: Path, sample_fps: float | None = None) -> bytes:
-    """Load a video file as MP4 bytes
+    """Load a video file as MP4 bytes, optionally subsampled to a lower fps.
+
     Args:
         input_file: Path to the video file.
+        sample_fps: If set and lower than the source fps, frames are dropped
+            so the output plays back at this rate. Defaults to None (returns
+            the original bytes unchanged).
 
     Returns:
         MP4-encoded video bytes.
     """
-    return input_file.read_bytes()
+    if sample_fps is None:
+        return input_file.read_bytes()
+
+    import tempfile
+
+    import cv2
+
+    cap = cv2.VideoCapture(str(input_file))
+    try:
+        source_fps = cap.get(cv2.CAP_PROP_FPS)
+        if not source_fps or sample_fps >= source_fps:
+            return input_file.read_bytes()
+
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        step = source_fps / sample_fps
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out_path = Path(tmp_dir) / "resampled.mp4"
+            fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore
+            writer = cv2.VideoWriter(str(out_path), fourcc, sample_fps, (width, height))
+            try:
+                next_frame = 0.0
+                frame_idx = 0
+                ok, frame = cap.read()
+                while ok:
+                    if frame_idx >= next_frame:
+                        writer.write(frame)
+                        next_frame += step
+                    frame_idx += 1
+                    ok, frame = cap.read()
+            finally:
+                writer.release()
+
+            logger.info(
+                "  Resampled video from {:.2f} fps to {:.2f} fps",
+                source_fps,
+                sample_fps,
+            )
+            return out_path.read_bytes()
+    finally:
+        cap.release()
 
 
 def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -218,26 +218,38 @@ def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
 def load_video(input_file: Path, sample_fps: float | None = None) -> bytes:
     """Load a video file as MP4 bytes, optionally subsampled to a lower fps.
 
+    Note that resampling re-encodes the video with OpenCV, which drops any
+    audio track the source file may have.
+
     Args:
         input_file: Path to the video file.
         sample_fps: If set and lower than the source fps, frames are dropped
             so the output plays back at this rate. Defaults to None (returns
-            the original bytes unchanged).
+            the original bytes unchanged). Must be positive.
 
     Returns:
         MP4-encoded video bytes.
     """
     if sample_fps is None:
         return input_file.read_bytes()
+    if sample_fps <= 0:
+        raise ValueError(f"sample_fps must be positive, got {sample_fps}")
 
+    import math
     import tempfile
 
     import cv2
 
     cap = cv2.VideoCapture(str(input_file))
+    if not cap.isOpened():
+        cap.release()
+        raise ValueError(f"Could not open video: {input_file}")
+
     try:
         source_fps = cap.get(cv2.CAP_PROP_FPS)
-        if not source_fps or sample_fps >= source_fps:
+        if not source_fps or math.isnan(source_fps):
+            raise ValueError(f"Could not determine FPS for video: {input_file}")
+        if sample_fps >= source_fps:
             return input_file.read_bytes()
 
         width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -248,6 +260,8 @@ def load_video(input_file: Path, sample_fps: float | None = None) -> bytes:
             out_path = Path(tmp_dir) / "resampled.mp4"
             fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore
             writer = cv2.VideoWriter(str(out_path), fourcc, sample_fps, (width, height))
+            if not writer.isOpened():
+                raise RuntimeError(f"Could not open video writer for: {input_file}")
             try:
                 next_frame = 0.0
                 frame_idx = 0
@@ -262,7 +276,8 @@ def load_video(input_file: Path, sample_fps: float | None = None) -> bytes:
                 writer.release()
 
             logger.info(
-                "  Resampled video from {:.2f} fps to {:.2f} fps",
+                "  Resampled video from {:.2f} fps to {:.2f} fps "
+                "(audio track, if any, is dropped)",
                 source_fps,
                 sample_fps,
             )

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -215,6 +215,17 @@ def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
     return np.ascontiguousarray(array, dtype=np.float32)
 
 
+def load_video(input_file: Path, sample_fps: float | None = None) -> bytes:
+    """Load a video file as MP4 bytes
+    Args:
+        input_file: Path to the video file.
+
+    Returns:
+        MP4-encoded video bytes.
+    """
+    return input_file.read_bytes()
+
+
 def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:
     """
     Parse a string or dict into a dict, trying JSON then Python literal syntax.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from tigerflow_ml.utils import (
@@ -15,7 +16,9 @@ from tigerflow_ml.utils import (
     get_model_config,
     get_model_context_window,
     get_tokenizer,
+    load_audio,
     load_images,
+    load_video,
     process_response_schema,
     read_text_file_strict,
     read_text_file_with_fallback,
@@ -313,6 +316,124 @@ class TestBatched:
 
     def test_empty_iterable_yields_nothing(self):
         assert list(batched(iter([]), 3)) == []
+
+
+def _make_audio_file(path, duration=1.0, sr=8000, channels=1, freq=440):
+    import numpy as np
+    import soundfile as sf
+
+    t = np.linspace(0, duration, int(duration * sr), endpoint=False)
+    tone = (0.1 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    if channels > 1:
+        tone = np.stack([tone] * channels, axis=1)
+    sf.write(path, tone, sr)
+    return path
+
+
+class TestLoadAudio:
+    def test_downmixes_stereo_to_mono(self, tmp_path):
+        path = _make_audio_file(tmp_path / "test.wav", sr=16000, channels=2)
+        array = load_audio(path, sampling_rate=16000)
+        assert array.ndim == 1
+
+    def test_returns_float32(self, tmp_path):
+        path = _make_audio_file(tmp_path / "test.wav", sr=16000)
+        array = load_audio(path, sampling_rate=16000)
+        assert array.dtype == np.float32
+
+    def test_no_resample_when_rate_matches(self, tmp_path):
+        path = _make_audio_file(tmp_path / "test.wav", duration=1.0, sr=16000)
+        array = load_audio(path, sampling_rate=16000)
+        assert len(array) == 16000
+
+    def test_resamples_to_target_rate(self, tmp_path):
+        path = _make_audio_file(tmp_path / "test.wav", duration=1.0, sr=8000)
+        array = load_audio(path, sampling_rate=16000)
+        assert abs(len(array) - 16000) == 0
+
+    def test_default_sampling_rate_is_16khz(self, tmp_path):
+        path = _make_audio_file(tmp_path / "test.wav", duration=1.0, sr=8000)
+        array = load_audio(path)
+        assert abs(len(array) - 16000) == 0
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        with pytest.raises(Exception):
+            load_audio(tmp_path / "nonexistent.wav")
+
+
+def _make_video_file(path, num_frames=10, fps=10.0, size=(32, 24)):
+    import cv2
+    import numpy as np
+
+    width, height = size
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, fps, (width, height))
+    try:
+        for i in range(num_frames):
+            frame = np.full((height, width, 3), i % 256, dtype=np.uint8)
+            writer.write(frame)
+    finally:
+        writer.release()
+    return path
+
+
+def _read_back(video_bytes, tmp_path, name="roundtrip.mp4"):
+    import cv2
+
+    out_path = tmp_path / name
+    out_path.write_bytes(video_bytes)
+    cap = cv2.VideoCapture(str(out_path))
+    try:
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    finally:
+        cap.release()
+    return fps, frame_count
+
+
+class TestLoadVideo:
+    def test_no_resample_when_sample_fps_is_none(self, tmp_path):
+        path = _make_video_file(tmp_path / "test.mp4", num_frames=10, fps=10.0)
+        result = load_video(path, sample_fps=None)
+        assert result == path.read_bytes()
+
+    def test_no_resample_when_sample_fps_above_source(self, tmp_path):
+        path = _make_video_file(tmp_path / "test.mp4", num_frames=10, fps=10.0)
+        result = load_video(path, sample_fps=30.0)
+        assert result == path.read_bytes()
+
+    def test_downsamples_frame_count(self, tmp_path):
+        path = _make_video_file(tmp_path / "test.mp4", num_frames=10, fps=10.0)
+        result = load_video(path, sample_fps=5.0)
+        fps, frame_count = _read_back(result, tmp_path)
+        assert abs(fps - 5.0) < 0.1
+        assert frame_count < 10
+
+    def test_zero_sample_fps_raises(self, tmp_path):
+        path = _make_video_file(tmp_path / "test.mp4", num_frames=10, fps=10.0)
+        with pytest.raises(ValueError, match="positive"):
+            load_video(path, sample_fps=0)
+
+    def test_negative_sample_fps_raises(self, tmp_path):
+        path = _make_video_file(tmp_path / "test.mp4", num_frames=10, fps=10.0)
+        with pytest.raises(ValueError, match="positive"):
+            load_video(path, sample_fps=-5.0)
+
+    def test_unopenable_file_raises(self, tmp_path):
+        path = tmp_path / "bad.mp4"
+        path.write_bytes(b"not a real video")
+        with pytest.raises(ValueError, match="Could not open video"):
+            load_video(path, sample_fps=5.0)
+
+    def test_nan_fps_raises(self, tmp_path):
+        path = _make_video_file(tmp_path / "test.mp4", num_frames=10, fps=10.0)
+        with patch("cv2.VideoCapture") as mock_capture:
+            mock_cap = MagicMock()
+            mock_cap.isOpened.return_value = True
+            mock_cap.get.return_value = float("nan")
+            mock_capture.return_value = mock_cap
+            with pytest.raises(ValueError, match="Could not determine FPS"):
+                load_video(path, sample_fps=5.0)
 
 
 class TestStripMarkdownFromJson:

--- a/tests/unit/text/chat/test_chat.py
+++ b/tests/unit/text/chat/test_chat.py
@@ -5,12 +5,16 @@ import io
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import numpy as np
 import PIL.Image
 import pytest
+import soundfile as sf
 
 from tigerflow_ml.text.chat._base import (
+    _build_audio_message,
     _build_img_message,
     _build_txt_message,
+    _build_video_message,
     _ChatBase,
 )
 from tigerflow_ml.utils import EmptyFileError
@@ -22,6 +26,8 @@ def _make_context(**kwargs):
         prompt="Describe this",
         system_message=None,
         max_image_pixels=None,
+        audio_sampling_rate=16000,
+        video_sample_fps=None,
         max_tokens=512,
         max_model_len=32000,
         allow_fetch=False,
@@ -205,3 +211,83 @@ class TestBuildImgMessage:
         raw = base64.b64decode(url.removeprefix("data:image/png;base64,"))
         decoded = PIL.Image.open(io.BytesIO(raw))
         assert decoded.size == (64, 48)
+
+
+class TestBuildAudioMessage:
+    @pytest.fixture
+    def audio_data(self):
+        return np.zeros(16000, dtype=np.float32)
+
+    def _user_content(self, messages):
+        return messages[-1]["content"]
+
+    def test_audio_comes_before_text(self, audio_data):
+        content = self._user_content(
+            _build_audio_message(
+                "Describe", audio_data, sampling_rate=16000, system_message=None
+            )
+        )
+        assert content[0]["type"] == "audio_url"
+        assert content[1]["type"] == "text"
+
+    def test_system_message_is_first(self, audio_data):
+        messages = _build_audio_message(
+            "Describe", audio_data, sampling_rate=16000, system_message="Be concise."
+        )
+        assert messages[0] == {"role": "system", "content": "Be concise."}
+        assert messages[1]["role"] == "user"
+
+    def test_no_system_message_single_user_turn(self, audio_data):
+        messages = _build_audio_message(
+            "Describe", audio_data, sampling_rate=16000, system_message=None
+        )
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    def test_base64_url_is_valid_wav_at_sampling_rate(self, audio_data):
+        content = self._user_content(
+            _build_audio_message(
+                "Describe", audio_data, sampling_rate=16000, system_message=None
+            )
+        )
+        url = next(c for c in content if c["type"] == "audio_url")["audio_url"]["url"]
+        assert url.startswith("data:audio/wav;base64,")
+        raw = base64.b64decode(url.removeprefix("data:audio/wav;base64,"))
+        decoded, sr = sf.read(io.BytesIO(raw))
+        assert sr == 16000
+        assert len(decoded) == len(audio_data)
+
+
+class TestBuildVideoMessage:
+    def _user_content(self, messages):
+        return messages[-1]["content"]
+
+    def test_video_comes_before_text(self):
+        content = self._user_content(
+            _build_video_message("Describe", b"fake-mp4-bytes", system_message=None)
+        )
+        assert content[0]["type"] == "video_url"
+        assert content[1]["type"] == "text"
+
+    def test_system_message_is_first(self):
+        messages = _build_video_message(
+            "Describe", b"fake-mp4-bytes", system_message="Be concise."
+        )
+        assert messages[0] == {"role": "system", "content": "Be concise."}
+        assert messages[1]["role"] == "user"
+
+    def test_no_system_message_single_user_turn(self):
+        messages = _build_video_message(
+            "Describe", b"fake-mp4-bytes", system_message=None
+        )
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    def test_base64_url_roundtrips_original_bytes(self):
+        content = self._user_content(
+            _build_video_message("Describe", b"fake-mp4-bytes", system_message=None)
+        )
+        url = next(c for c in content if c["type"] == "video_url")["video_url"]["url"]
+        assert url.startswith("data:video/mp4;base64,")
+        raw = base64.b64decode(url.removeprefix("data:video/mp4;base64,"))
+        assert raw == b"fake-mp4-bytes"

--- a/tests/unit/text/chat/test_chat.py
+++ b/tests/unit/text/chat/test_chat.py
@@ -180,7 +180,7 @@ class TestBuildImgMessage:
         content = self._user_content(
             _build_img_message("Describe", image, system_message=None)
         )
-        assert content[0]["type"] == "image_url"
+        assert content[0]["type"] == "image_pil"
         assert content[1]["type"] == "text"
 
     def test_system_message_is_first(self, image):
@@ -192,25 +192,6 @@ class TestBuildImgMessage:
         messages = _build_img_message("Describe", image, system_message=None)
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
-
-    def test_base64_url_is_valid_png(self, image):
-        content = self._user_content(
-            _build_img_message("Describe", image, system_message=None)
-        )
-        url = next(c for c in content if c["type"] == "image_url")["image_url"]["url"]
-        assert url.startswith("data:image/png;base64,")
-        raw = base64.b64decode(url.removeprefix("data:image/png;base64,"))
-        decoded = PIL.Image.open(io.BytesIO(raw))
-        assert decoded.format == "PNG"
-
-    def test_base64_image_has_correct_dimensions(self, image):
-        content = self._user_content(
-            _build_img_message("Describe", image, system_message=None)
-        )
-        url = next(c for c in content if c["type"] == "image_url")["image_url"]["url"]
-        raw = base64.b64decode(url.removeprefix("data:image/png;base64,"))
-        decoded = PIL.Image.open(io.BytesIO(raw))
-        assert decoded.size == (64, 48)
 
 
 class TestBuildAudioMessage:

--- a/tests/unit/text/chat/test_params.py
+++ b/tests/unit/text/chat/test_params.py
@@ -6,3 +6,5 @@ def test_chat_defaults():
     assert p.max_image_pixels is None
     assert p.temperature == 0.0
     assert p.response_schema is None
+    assert p.audio_sampling_rate == 16000
+    assert p.video_sample_fps is None


### PR DESCRIPTION
### `Chat` task can now process audio and video files
- Adds new parameter `--audio_sampling_rate`
- Adds new parameter `--video_sample_fps` 
- Adds `load_audio()` and `load_video()` to the shared utils


## Open questions
- I think having something like `--video_sample_fps` is good to have to resize large videos, but I'm not sure if this is the best way to go about it, mainly because it drops any audio associated with the video. 
- Integration tests could be added to test every media type -- this would just require adding new models to the `chat` tests