### PR TITLE
feat: add embed task for text embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install tigerflow-ml[vllm]
 | Chat             | Apply a chat prompt to text, images, audio, or video | `chat` / `chat-local`             |
 | Transcription    | Transcribe audio to text              | `transcribe` / `transcribe-local` |
 | Object Detection | Detect objects in images and videos   | `detect` / `detect-local`         |
+| Embed            | Embed text documents                  | `embed` / `embed-local`           |
 
 Each task provides both a Slurm variant (for HPC) and a Local variant (for development).
 
@@ -47,6 +48,7 @@ python -m tigerflow_ml.text.translate.slurm --help
 python -m tigerflow_ml.text.chat.slurm --help
 python -m tigerflow_ml.audio.transcribe.slurm --help
 python -m tigerflow_ml.image.detect.slurm --help
+python -m tigerflow_ml.text.embed.slurm --help
 ```
 
 ## Container

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -65,3 +65,4 @@ nav:
       - Transcription: tasks/transcribe.md
       - Object Detection: tasks/detect.md
       - Chat: tasks/chat.md
+      - Embed: tasks/embed.md

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -40,6 +40,7 @@ hide:
 - [Transcription](tasks/transcribe.md) — Transcribe audio to text
 - [Object Detection](tasks/detect.md) — Detect objects in images and videos
 - [Chat](tasks/chat.md) - Apply a chat prompt to text, image, audio, or video documents
+- [Embed](tasks/embed.md) - Embed text using HuggingFace sentence-transformers models
 
 ## Installation
 

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -12,8 +12,6 @@ Embed text using HuggingFace sentence-transformers models.
 | `--device`          | `auto`             | Device to use (`cuda`, `cpu`, or `auto`)                                                                            |
 | `--allow-fetch`     | `--no-allow-fetch` | Allow downloads from HuggingFace Hub (network access required)                                                     |
 | `--seed`            | `42`               | The seed to set for more reproducible behavior                                                                     |
-| `--per-line`        | `--no-per-line`    | Embed each non-empty line of the input file independently, producing one vector per line instead of a single vector for the whole file |
-| `--batch-size`      | `32`               | Number of lines encoded per batch when `--per-line` is set                                                         |
 | `--prompt`          |                    | Raw text prepended to each input before encoding (e.g. `query: `). Mutually exclusive with `--prompt-name`         |
 | `--prompt-name`     |                    | Name of a prompt predefined in the model's config (e.g. `query` or `passage` for e5/bge models). Mutually exclusive with `--prompt` |
 | `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
@@ -26,9 +24,6 @@ Text files (`.txt`, `.text`, `.md`, `.log`, `.rtf`)
 ## Output Format
 
 NumPy binary (`.npy`).
-
-- By default, the whole file is embedded as one document, producing a 1-D array of shape `(dim,)`.
-- With `--per-line`, each non-empty line is embedded independently, producing a 2-D array of shape `(n_lines, dim)`.
 
 ## Models
 
@@ -61,39 +56,6 @@ Any HuggingFace model compatible with the [sentence-transformers](https://sbert.
 === "Output (.npy)"
 
     A single vector of shape `(384,)`.
-
-### Embed each line independently
-
-Use `--per-line` to embed a corpus file with one record per line, producing one vector per line instead of a single document vector.
-
-=== "Config"
-
-    ```yaml title="config.yaml"
-    tasks:
-      - name: embed
-        kind: local
-        module: tigerflow_ml.text.embed.local
-        input_ext: .txt
-        output_ext: .npy
-        params:
-          model: sentence-transformers/all-MiniLM-L6-v2
-          per-line: True
-          batch-size: 3
-          allow-fetch: True
-    ```
-
-=== "Input (.txt)"
-
-    ```text title="corpus.txt"
-    The quick brown fox jumps over the lazy dog.
-    Princeton University is in New Jersey.
-    Embeddings map text to dense vectors.
-    ```
-
-=== "Output (.npy)"
-
-    An array of shape `(3, 384)` — one row per line.
-
 
 ### Run on HPC with Slurm
 

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -15,6 +15,7 @@ Embed text using HuggingFace sentence-transformers models.
 | `--encode-kwargs`   | `{}`               | Additional kwargs for SentenceTransformer's `encode()` (e.g. `{'prompt':'query: '}`). Supplied values override task defaults. |
 | `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
 | `--truncate-dim`    |                    | The dimension to truncate sentence embeddings to                                                                   |
+| `--use-encode-document` | `--no-use-encode-document` | Use SentenceTransformer's `encode_document()` instead of `encode()`. See [SentenceTransformer's documentation](https://sbert.net/docs/package_reference/sentence_transformer/model.html#sentence_transformers.sentence_transformer.model.SentenceTransformer.encode_document) for more information. |
 
 ## Supported Input Formats
 

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -1,0 +1,120 @@
+# Embed
+
+Embed text using HuggingFace sentence-transformers models.
+
+## Parameters
+
+| Parameter          | Default            | Description                                                                                                      |
+|---------------------|--------------------|--------------------------------------------------------------------------------------------------------------------|
+| `--model`           |                    | HuggingFace model repo ID                                                                                          |
+| `--revision`        | `main`             | Model revision (branch, tag, or commit hash)                                                                       |
+| `--cache-dir`       |                    | HuggingFace cache directory for model files                                                                        |
+| `--device`          | `auto`             | Device to use (`cuda`, `cpu`, or `auto`)                                                                            |
+| `--allow-fetch`     | `--no-allow-fetch` | Allow downloads from HuggingFace Hub (network access required)                                                     |
+| `--seed`            | `42`               | The seed to set for more reproducible behavior                                                                     |
+| `--per-line`        | `--no-per-line`    | Embed each non-empty line of the input file independently, producing one vector per line instead of a single vector for the whole file |
+| `--batch-size`      | `32`               | Number of lines encoded per batch when `--per-line` is set                                                         |
+| `--prompt`          |                    | Raw text prepended to each input before encoding (e.g. `query: `). Mutually exclusive with `--prompt-name`         |
+| `--prompt-name`     |                    | Name of a prompt predefined in the model's config (e.g. `query` or `passage` for e5/bge models). Mutually exclusive with `--prompt` |
+| `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
+| `--truncate-dim`    |                    | The dimension to truncate sentence embeddings to                                                                   |
+
+## Supported Input Formats
+
+Text files (`.txt`, `.text`, `.md`, `.log`, `.rtf`)
+
+## Output Format
+
+NumPy binary (`.npy`).
+
+- By default, the whole file is embedded as one document, producing a 1-D array of shape `(dim,)`.
+- With `--per-line`, each non-empty line is embedded independently, producing a 2-D array of shape `(n_lines, dim)`.
+
+## Models
+
+Any HuggingFace model compatible with the [sentence-transformers](https://sbert.net) library, including plain encoder models.
+
+## Examples
+
+### Embed a document
+
+=== "Config"
+
+    ```yaml title="config.yaml"
+    tasks:
+      - name: embed
+        kind: local
+        module: tigerflow_ml.text.embed.local
+        input_ext: .txt
+        output_ext: .npy
+        params:
+          model: sentence-transformers/all-MiniLM-L6-v2
+          allow-fetch: True
+    ```
+
+=== "Input (.txt)"
+
+    ```text title="Raven.txt"
+    "The Raven" by Edgar Allan Poe
+    ```
+
+=== "Output (.npy)"
+
+    A single vector of shape `(384,)`.
+
+### Embed each line independently
+
+Use `--per-line` to embed a corpus file with one record per line, producing one vector per line instead of a single document vector.
+
+=== "Config"
+
+    ```yaml title="config.yaml"
+    tasks:
+      - name: embed
+        kind: local
+        module: tigerflow_ml.text.embed.local
+        input_ext: .txt
+        output_ext: .npy
+        params:
+          model: sentence-transformers/all-MiniLM-L6-v2
+          per-line: True
+          batch-size: 3
+          allow-fetch: True
+    ```
+
+=== "Input (.txt)"
+
+    ```text title="corpus.txt"
+    The quick brown fox jumps over the lazy dog.
+    Princeton University is in New Jersey.
+    Embeddings map text to dense vectors.
+    ```
+
+=== "Output (.npy)"
+
+    An array of shape `(3, 384)` — one row per line.
+
+
+### Run on HPC with Slurm
+
+For bulk embedding across large text collections, use the Slurm variant to distribute work across compute nodes:
+
+```yaml title="config.yaml"
+tasks:
+  - name: embed
+    kind: slurm
+    module: tigerflow_ml.text.embed.slurm
+    input_ext: .txt
+    output_ext: .npy
+    max_workers: 4
+    worker_resources:
+      cpus: 2
+      gpus: 1
+      memory: 16G
+      time: 04:00:00
+    params:
+      model: BAAI/bge-base-en-v1.5
+      per_line: True
+      batch_size: 64
+      cache_dir: ~/path/to/model/hub
+```

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -4,16 +4,15 @@ Embed text using HuggingFace sentence-transformers models.
 
 ## Parameters
 
-| Parameter          | Default            | Description                                                                                                      |
+| Parameter          | Default            | Description                                                                                                         |
 |---------------------|--------------------|--------------------------------------------------------------------------------------------------------------------|
 | `--model`           |                    | HuggingFace model repo ID                                                                                          |
 | `--revision`        | `main`             | Model revision (branch, tag, or commit hash)                                                                       |
 | `--cache-dir`       |                    | HuggingFace cache directory for model files                                                                        |
-| `--device`          | `auto`             | Device to use (`cuda`, `cpu`, or `auto`)                                                                            |
+| `--device`          | `auto`             | Device to use (`cuda`, `cpu`, or `auto`)                                                                           |
 | `--allow-fetch`     | `--no-allow-fetch` | Allow downloads from HuggingFace Hub (network access required)                                                     |
 | `--seed`            | `42`               | The seed to set for more reproducible behavior                                                                     |
-| `--prompt`          |                    | Raw text prepended to each input before encoding (e.g. `query: `). Mutually exclusive with `--prompt-name`         |
-| `--prompt-name`     |                    | Name of a prompt predefined in the model's config (e.g. `query` or `passage` for e5/bge models). Mutually exclusive with `--prompt` |
+| `--encode-kwargs`   | `{}`               | Additional kwargs for SentenceTransformer's `encode()` (e.g. `{'prompt':'query: '}`). Supplied values override task defaults. |
 | `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
 | `--truncate-dim`    |                    | The dimension to truncate sentence embeddings to                                                                   |
 
@@ -76,7 +75,6 @@ tasks:
       time: 04:00:00
     params:
       model: BAAI/bge-base-en-v1.5
-      per_line: True
-      batch_size: 64
+      encode-kwargs: {"prompt":"query: "}
       cache_dir: ~/path/to/model/hub
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "soundfile>=0.12",
     "soxr>=0.3",
     "pillow-heif>=1.4.0",
+    "sentence-transformers>=5.6.0",
 ]
 
 [project.optional-dependencies]
@@ -78,6 +79,8 @@ detect = "tigerflow_ml.image.detect.slurm:Detect"
 detect-local = "tigerflow_ml.image.detect.local:Detect"
 chat = "tigerflow_ml.text.chat.slurm:Chat"
 chat-local = "tigerflow_ml.text.chat.local:Chat"
+embed = "tigerflow_ml.text.embed.slurm:Embed"
+embed-local = "tigerflow_ml.text.embed.local:Embed"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/tigerflow_ml/__init__.py
+++ b/src/tigerflow_ml/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from tigerflow_ml.audio.transcribe.slurm import Transcribe
     from tigerflow_ml.image.detect.slurm import Detect
     from tigerflow_ml.text.chat.slurm import Chat
+    from tigerflow_ml.text.embed.slurm import Embed
     from tigerflow_ml.text.ocr.slurm import OCR
     from tigerflow_ml.text.translate.slurm import Translate
 
@@ -19,9 +20,10 @@ _LAZY_TASKS = {
     "Transcribe": "tigerflow_ml.audio.transcribe.slurm",
     "Detect": "tigerflow_ml.image.detect.slurm",
     "Chat": "tigerflow_ml.text.chat.slurm",
+    "Embed": "tigerflow_ml.text.embed.slurm",
 }
 
-__all__ = ["OCR", "Translate", "Transcribe", "Detect", "Chat"]
+__all__ = ["OCR", "Translate", "Transcribe", "Detect", "Chat", "Embed"]
 
 
 def __getattr__(name: str):

--- a/src/tigerflow_ml/text/embed/__init__.py
+++ b/src/tigerflow_ml/text/embed/__init__.py
@@ -1,0 +1,14 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tigerflow_ml.text.embed.slurm import Embed
+
+__all__ = ["Embed"]
+
+
+def __getattr__(name: str):
+    if name == "Embed":
+        from tigerflow_ml.text.embed.slurm import Embed
+
+        return Embed
+    raise AttributeError(f"module 'tigerflow_ml.text.embed' has no attribute {name!r}")

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import numpy as np
 import typer
@@ -33,14 +33,48 @@ class _EmbedBase:
             ),
         ] = 32
 
+        prompt: Annotated[
+            str | None,
+            typer.Option(
+                help="Raw text prepended to each input before encoding (e.g. "
+                "'query: '). Mutually exclusive with --prompt-name."
+            ),
+        ] = None
+
+        prompt_name: Annotated[
+            str | None,
+            typer.Option(
+                help="Name of a prompt predefined in the model's config (e.g. "
+                "'query' or 'passage' for e5/bge models). Mutually exclusive "
+                "with --prompt."
+            ),
+        ] = None
+
+        normalize: Annotated[
+            bool,
+            typer.Option(
+                help="Whether to normalize returned vectors to have length 1."
+            ),
+        ] = False
+
+        truncate_dim: Annotated[
+            int | None,
+            typer.Option(help="The dimension to truncate sentence embeddings to."),
+        ] = None
+
     @staticmethod
     def setup(context: SetupContext):
         import torch
         from sentence_transformers import SentenceTransformer
 
+        if context.prompt is not None and context.prompt_name is not None:
+            raise ValueError("--prompt and --prompt-name are mutually exclusive")
+
         device = context.device
         if context.device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        torch.manual_seed(context.seed)
 
         try:
             context.embedder = SentenceTransformer(
@@ -69,8 +103,22 @@ class _EmbedBase:
                 "save to a .npy file."
             )
 
+        encode_kwargs = {
+            "normalize_embeddings": context.normalize,
+            "show_progress_bar": False,
+        }
+        if context.prompt is not None:
+            encode_kwargs["prompt"] = context.prompt
+        if context.prompt_name is not None:
+            encode_kwargs["prompt_name"] = context.prompt_name
+        if context.truncate_dim is not None:
+            encode_kwargs["truncate_dim"] = context.truncate_dim
+        logger.info(f"   Encode kwargs: {encode_kwargs}")
+
         if input_file.suffix.lower() in _TEXT_EXTENSIONS:
-            embeddings = _EmbedBase._embed_text(context=context, input_file=input_file)
+            embeddings = _EmbedBase._embed_text(
+                context=context, input_file=input_file, encode_kwargs=encode_kwargs
+            )
         else:
             raise ValueError(
                 f"File extension {input_file.suffix} not currently supported - "
@@ -79,15 +127,19 @@ class _EmbedBase:
         np.save(output_file, embeddings)
 
     @staticmethod
-    def _embed_text(context: SetupContext, input_file: Path):
+    def _embed_text(
+        context: SetupContext, input_file: Path, encode_kwargs: dict[str, Any]
+    ):
         content = read_text_file_strict(input_file)
         if context.per_line:
             texts = [line.strip() for line in content.splitlines() if line.strip()]
-            embeddings = context.embedder.encode(texts, batch_size=context.batch_size)
+            embeddings = context.embedder.encode(
+                texts, batch_size=context.batch_size, **encode_kwargs
+            )
             logger.info(
                 f"   Embedded {len(texts)} line(s) with shape {embeddings.shape}"
             )
         else:
-            embeddings = context.embedder.encode(content)
+            embeddings = context.embedder.encode_document(content, **encode_kwargs)
             logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
         return embeddings

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -7,7 +7,7 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
-from tigerflow_ml.utils import read_text_file_strict
+from tigerflow_ml.utils import parse_kwargs, read_text_file_strict
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 
@@ -16,23 +16,6 @@ class _EmbedBase:
     """Embed inputs using Hugging Face sentence-transformers models."""
 
     class Params(HFParams):
-        prompt: Annotated[
-            str | None,
-            typer.Option(
-                help="Raw text prepended to each input before encoding (e.g. "
-                "'query: '). Mutually exclusive with --prompt-name."
-            ),
-        ] = None
-
-        prompt_name: Annotated[
-            str | None,
-            typer.Option(
-                help="Name of a prompt predefined in the model's config (e.g. "
-                "'query' or 'passage' for e5/bge models). Mutually exclusive "
-                "with --prompt."
-            ),
-        ] = None
-
         normalize: Annotated[
             bool,
             typer.Option(
@@ -45,13 +28,18 @@ class _EmbedBase:
             typer.Option(help="The dimension to truncate sentence embeddings to."),
         ] = None
 
+        encode_kwargs: Annotated[
+            str,
+            typer.Option(
+                help="Additional kwargs for SentenceTransformer's encode() "
+                "(e.g., {'prompt':'query: '}). Supplied values override task defaults."
+            ),
+        ] = "{}"
+
     @staticmethod
     def setup(context: SetupContext):
         import torch
         from sentence_transformers import SentenceTransformer
-
-        if context.prompt is not None and context.prompt_name is not None:
-            raise ValueError("--prompt and --prompt-name are mutually exclusive")
 
         device = context.device
         if context.device == "auto":
@@ -78,6 +66,16 @@ class _EmbedBase:
             f"   Embedding dimension: {context.embedder.get_embedding_dimension()}"
         )
 
+        user_encode_kwargs = parse_kwargs(context.encode_kwargs)
+        context.encode_kwargs = {
+            "normalize_embeddings": context.normalize,
+            "show_progress_bar": False,
+        }
+        if context.truncate_dim is not None:
+            context.encode_kwargs["truncate_dim"] = context.truncate_dim
+        context.encode_kwargs.update(user_encode_kwargs)
+        logger.info(f"   encode_kwargs={context.encode_kwargs}")
+
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
         if output_file.suffix.lower() != ".npy":
@@ -86,21 +84,11 @@ class _EmbedBase:
                 "save to a .npy file."
             )
 
-        encode_kwargs = {
-            "normalize_embeddings": context.normalize,
-            "show_progress_bar": False,
-        }
-        if context.prompt is not None:
-            encode_kwargs["prompt"] = context.prompt
-        if context.prompt_name is not None:
-            encode_kwargs["prompt_name"] = context.prompt_name
-        if context.truncate_dim is not None:
-            encode_kwargs["truncate_dim"] = context.truncate_dim
-        logger.info(f"   Encode kwargs: {encode_kwargs}")
-
         if input_file.suffix.lower() in _TEXT_EXTENSIONS:
             embeddings = _EmbedBase._embed_text(
-                context=context, input_file=input_file, encode_kwargs=encode_kwargs
+                context=context,
+                input_file=input_file,
+                encode_kwargs=context.encode_kwargs,
             )
         else:
             raise ValueError(

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -16,23 +16,6 @@ class _EmbedBase:
     """Embed inputs using Hugging Face sentence-transformers models."""
 
     class Params(HFParams):
-        per_line: Annotated[
-            bool,
-            typer.Option(
-                help="Embed each non-empty line of the input file independently, "
-                "producing one vector per line instead of a single vector for the "
-                "whole file."
-            ),
-        ] = False
-
-        batch_size: Annotated[
-            int,
-            typer.Option(
-                help="Number of lines encoded per batch when --per-line is set.",
-                min=1,
-            ),
-        ] = 32
-
         prompt: Annotated[
             str | None,
             typer.Option(
@@ -131,15 +114,7 @@ class _EmbedBase:
         context: SetupContext, input_file: Path, encode_kwargs: dict[str, Any]
     ):
         content = read_text_file_strict(input_file)
-        if context.per_line:
-            texts = [line.strip() for line in content.splitlines() if line.strip()]
-            embeddings = context.embedder.encode(
-                texts, batch_size=context.batch_size, **encode_kwargs
-            )
-            logger.info(
-                f"   Embedded {len(texts)} line(s) with shape {embeddings.shape}"
-            )
-        else:
-            embeddings = context.embedder.encode_document(content, **encode_kwargs)
-            logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
+
+        embeddings = context.embedder.encode_document(content, **encode_kwargs)
+        logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
         return embeddings

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -16,6 +16,14 @@ class _EmbedBase:
     """Embed inputs using Hugging Face sentence-transformers models."""
 
     class Params(HFParams):
+        use_encode_document: Annotated[
+            bool,
+            typer.Option(
+                help="Whether to use SentenceTransformer's encode_document() "
+                "method instead of the regular encode()."
+            ),
+        ] = False
+
         normalize: Annotated[
             bool,
             typer.Option(
@@ -103,6 +111,9 @@ class _EmbedBase:
     ):
         content = read_text_file_strict(input_file)
 
-        embeddings = context.embedder.encode_document(content, **encode_kwargs)
+        if context.use_encode_document:
+            embeddings = context.embedder.encode_document(content, **encode_kwargs)
+        else:
+            embeddings = context.embedder.encode(content, **encode_kwargs)
         logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
         return embeddings

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from typing import Annotated
+
+import numpy as np
+import typer
+from tigerflow.logconfig import logger
+from tigerflow.utils import SetupContext
+
+from tigerflow_ml.params import HFParams
+from tigerflow_ml.utils import read_text_file_strict
+
+_TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
+
+
+class _EmbedBase:
+    """Embed inputs using Hugging Face sentence-transformers models."""
+
+    class Params(HFParams):
+        per_line: Annotated[
+            bool,
+            typer.Option(
+                help="Embed each non-empty line of the input file independently, "
+                "producing one vector per line instead of a single vector for the "
+                "whole file."
+            ),
+        ] = False
+
+        batch_size: Annotated[
+            int,
+            typer.Option(
+                help="Number of lines encoded per batch when --per-line is set.",
+                min=1,
+            ),
+        ] = 32
+
+    @staticmethod
+    def setup(context: SetupContext):
+        import torch
+        from sentence_transformers import SentenceTransformer
+
+        device = context.device
+        if context.device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        try:
+            context.embedder = SentenceTransformer(
+                context.model,
+                revision=context.revision,
+                cache_folder=context.cache_dir,
+                device=device,
+                local_files_only=not context.allow_fetch,
+            )
+        except OSError as e:
+            if not context.allow_fetch:
+                raise RuntimeError(
+                    f"'{context.model}' not found in cache ({context.cache_dir}). "
+                    "Run with --allow_fetch or download manually."
+                ) from e
+            raise
+        logger.info(
+            f"   Embedding dimension: {context.embedder.get_embedding_dimension()}"
+        )
+
+    @staticmethod
+    def run(context: SetupContext, input_file: Path, output_file: Path):
+        if output_file.suffix.lower() != ".npy":  # TODO: support json?
+            raise ValueError(
+                f"{output_file.suffix} is not a supported output for embed — "
+                "save to a .npy file."
+            )
+
+        if input_file.suffix.lower() in _TEXT_EXTENSIONS:
+            embeddings = _EmbedBase._embed_text(context=context, input_file=input_file)
+        else:
+            raise ValueError(
+                f"File extension {input_file.suffix} not currently supported - "
+                "raise an issue on Github"
+            )
+        np.save(output_file, embeddings)
+
+    @staticmethod
+    def _embed_text(context: SetupContext, input_file: Path):
+        content = read_text_file_strict(input_file)
+        if context.per_line:
+            texts = [line.strip() for line in content.splitlines() if line.strip()]
+            embeddings = context.embedder.encode(texts, batch_size=context.batch_size)
+            logger.info(
+                f"   Embedded {len(texts)} line(s) with shape {embeddings.shape}"
+            )
+        else:
+            embeddings = context.embedder.encode(content)
+            logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
+        return embeddings

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -97,7 +97,7 @@ class _EmbedBase:
 
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
-        if output_file.suffix.lower() != ".npy":  # TODO: support json?
+        if output_file.suffix.lower() != ".npy":
             raise ValueError(
                 f"{output_file.suffix} is not a supported output for embed — "
                 "save to a .npy file."

--- a/src/tigerflow_ml/text/embed/local.py
+++ b/src/tigerflow_ml/text/embed/local.py
@@ -1,0 +1,11 @@
+from tigerflow.tasks import LocalTask
+
+from tigerflow_ml.text.embed._base import _EmbedBase
+
+
+class Embed(_EmbedBase, LocalTask):
+    """Embed task for local execution."""
+
+
+if __name__ == "__main__":
+    Embed.cli()

--- a/src/tigerflow_ml/text/embed/slurm.py
+++ b/src/tigerflow_ml/text/embed/slurm.py
@@ -1,0 +1,11 @@
+from tigerflow.tasks import SlurmTask
+
+from tigerflow_ml.text.embed._base import _EmbedBase
+
+
+class Embed(_EmbedBase, SlurmTask):
+    """Embed task for Slurm execution."""
+
+
+if __name__ == "__main__":
+    Embed.cli()

--- a/tests/unit/test_entry_points.py
+++ b/tests/unit/test_entry_points.py
@@ -17,6 +17,8 @@ def test_entry_points_registered():
         "detect-local",
         "chat",
         "chat-local",
+        "embed",
+        "embed-local",
     }
     assert expected.issubset(names), f"Missing entry points: {expected - names}"
 

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -4,23 +4,25 @@ from tigerflow.tasks import LocalTask, SlurmTask
 
 
 def test_top_level_imports():
-    from tigerflow_ml import OCR, Chat, Detect, Transcribe, Translate
+    from tigerflow_ml import OCR, Chat, Detect, Embed, Transcribe, Translate
 
     assert OCR is not None
     assert Translate is not None
     assert Transcribe is not None
     assert Detect is not None
     assert Chat is not None
+    assert Embed is not None
 
 
 def test_local_variants_importable():
     from tigerflow_ml.audio.transcribe.local import Transcribe
     from tigerflow_ml.image.detect.local import Detect
     from tigerflow_ml.text.chat.local import Chat
+    from tigerflow_ml.text.embed.local import Embed
     from tigerflow_ml.text.ocr.local import OCR
     from tigerflow_ml.text.translate.local import Translate
 
-    for cls in (OCR, Translate, Transcribe, Detect, Chat):
+    for cls in (OCR, Translate, Transcribe, Detect, Chat, Embed):
         assert issubclass(cls, LocalTask)
 
 
@@ -28,17 +30,18 @@ def test_slurm_variants_importable():
     from tigerflow_ml.audio.transcribe.slurm import Transcribe
     from tigerflow_ml.image.detect.slurm import Detect
     from tigerflow_ml.text.chat.slurm import Chat
+    from tigerflow_ml.text.embed.slurm import Embed
     from tigerflow_ml.text.ocr.slurm import OCR
     from tigerflow_ml.text.translate.slurm import Translate
 
-    for cls in (OCR, Translate, Transcribe, Detect, Chat):
+    for cls in (OCR, Translate, Transcribe, Detect, Chat, Embed):
         assert issubclass(cls, SlurmTask)
 
 
 def test_each_task_has_params():
-    from tigerflow_ml import OCR, Chat, Detect, Transcribe, Translate
+    from tigerflow_ml import OCR, Chat, Detect, Embed, Transcribe, Translate
 
-    for cls in (OCR, Translate, Transcribe, Detect, Chat):
+    for cls in (OCR, Translate, Transcribe, Detect, Chat, Embed):
         assert hasattr(cls, "Params")
         assert hasattr(cls, "setup")
         assert hasattr(cls, "run")

--- a/tests/unit/test_wiring.py
+++ b/tests/unit/test_wiring.py
@@ -32,6 +32,12 @@ _TASKS = [
         "tigerflow_ml.text.chat.local",
         "tigerflow_ml.text.chat.slurm",
     ),
+    (
+        "embed",
+        ".txt",
+        "tigerflow_ml.text.embed.local",
+        "tigerflow_ml.text.embed.slurm",
+    ),
 ]
 
 

--- a/tests/unit/text/embed/test_embed.py
+++ b/tests/unit/text/embed/test_embed.py
@@ -21,6 +21,7 @@ def _make_context(**kwargs):
         encode_kwargs="{}",
         normalize=False,
         truncate_dim=None,
+        use_encode_document=False,
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -37,7 +38,7 @@ class TestRun:
     def _run(self, tmp_path, content, **context_kwargs):
         context = _make_context(**context_kwargs)
         context.embedder = MagicMock()
-        context.embedder.encode.return_value = np.zeros((3, 4))
+        context.embedder.encode.return_value = np.zeros(4)
         context.embedder.encode_document.return_value = np.zeros(4)
 
         # Mirrors the resolution _EmbedBase.setup() performs on context.encode_kwargs.
@@ -77,19 +78,10 @@ class TestRun:
         with pytest.raises(EmptyFileError):
             _EmbedBase.run(context, input_file, output_file)
 
-    def test_whole_file_uses_encode_document(self, tmp_path):
-        context, output_file = self._run(tmp_path, "hello world")
-
-        context.embedder.encode_document.assert_called_once()
-        context.embedder.encode.assert_not_called()
-        args, _ = context.embedder.encode_document.call_args
-        assert args[0] == "hello world"
-        assert output_file.exists()
-
     def test_encode_kwargs_omit_unset_optional_fields(self, tmp_path):
         context, _ = self._run(tmp_path, "hello")
 
-        _, kwargs = context.embedder.encode_document.call_args
+        _, kwargs = context.embedder.encode.call_args
         assert "truncate_dim" not in kwargs
         assert kwargs["normalize_embeddings"] is False
 
@@ -101,7 +93,7 @@ class TestRun:
             normalize=True,
         )
 
-        _, kwargs = context.embedder.encode_document.call_args
+        _, kwargs = context.embedder.encode.call_args
         assert kwargs["truncate_dim"] == 128
         assert kwargs["normalize_embeddings"] is True
 
@@ -110,3 +102,23 @@ class TestRun:
 
         loaded = np.load(output_file)
         assert loaded.shape == (4,)
+
+    def test_uses_encode_by_default(self, tmp_path):
+        context, output_file = self._run(tmp_path, "hello world")
+
+        context.embedder.encode.assert_called_once()
+        context.embedder.encode_document.assert_not_called()
+        args, _ = context.embedder.encode.call_args
+        assert args[0] == "hello world"
+        assert output_file.exists()
+
+    def test_uses_encode_document_when_set(self, tmp_path):
+        context, output_file = self._run(
+            tmp_path, "hello world", use_encode_document=True
+        )
+
+        context.embedder.encode_document.assert_called_once()
+        context.embedder.encode.assert_not_called()
+        args, _ = context.embedder.encode_document.call_args
+        assert args[0] == "hello world"
+        assert output_file.exists()

--- a/tests/unit/text/embed/test_embed.py
+++ b/tests/unit/text/embed/test_embed.py
@@ -18,8 +18,6 @@ def _make_context(**kwargs):
         device="auto",
         allow_fetch=False,
         seed=42,
-        per_line=False,
-        batch_size=32,
         prompt=None,
         prompt_name=None,
         normalize=False,
@@ -84,20 +82,6 @@ class TestRun:
         assert args[0] == "hello world"
         assert output_file.exists()
 
-    def test_per_line_uses_encode_with_batch_size(self, tmp_path):
-        context, _ = self._run(
-            tmp_path,
-            "line one\n\nline two\n  \nline three",
-            per_line=True,
-            batch_size=8,
-        )
-
-        context.embedder.encode.assert_called_once()
-        context.embedder.encode_document.assert_not_called()
-        args, kwargs = context.embedder.encode.call_args
-        assert args[0] == ["line one", "line two", "line three"]
-        assert kwargs["batch_size"] == 8
-
     def test_encode_kwargs_omit_unset_optional_fields(self, tmp_path):
         context, _ = self._run(tmp_path, "hello")
 
@@ -127,9 +111,3 @@ class TestRun:
 
         loaded = np.load(output_file)
         assert loaded.shape == (4,)
-
-    def test_per_line_output_written_as_npy(self, tmp_path):
-        _, output_file = self._run(tmp_path, "one\ntwo\nthree", per_line=True)
-
-        loaded = np.load(output_file)
-        assert loaded.shape == (3, 4)

--- a/tests/unit/text/embed/test_embed.py
+++ b/tests/unit/text/embed/test_embed.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from tigerflow_ml.text.embed._base import _EmbedBase
-from tigerflow_ml.utils import EmptyFileError
+from tigerflow_ml.utils import EmptyFileError, parse_kwargs
 
 
 def _make_context(**kwargs):
@@ -18,8 +18,7 @@ def _make_context(**kwargs):
         device="auto",
         allow_fetch=False,
         seed=42,
-        prompt=None,
-        prompt_name=None,
+        encode_kwargs="{}",
         normalize=False,
         truncate_dim=None,
     )
@@ -28,11 +27,6 @@ def _make_context(**kwargs):
 
 
 class TestSetup:
-    def test_prompt_and_prompt_name_mutually_exclusive(self):
-        context = _make_context(prompt="query: ", prompt_name="query")
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            _EmbedBase.setup(context)
-
     def test_model_not_found_without_allow_fetch_raises(self):
         context = _make_context(allow_fetch=False)
         with pytest.raises(RuntimeError, match="not found in cache"):
@@ -45,6 +39,16 @@ class TestRun:
         context.embedder = MagicMock()
         context.embedder.encode.return_value = np.zeros((3, 4))
         context.embedder.encode_document.return_value = np.zeros(4)
+
+        # Mirrors the resolution _EmbedBase.setup() performs on context.encode_kwargs.
+        user_encode_kwargs = parse_kwargs(context.encode_kwargs)
+        context.encode_kwargs = {
+            "normalize_embeddings": context.normalize,
+            "show_progress_bar": False,
+        }
+        if context.truncate_dim is not None:
+            context.encode_kwargs["truncate_dim"] = context.truncate_dim
+        context.encode_kwargs.update(user_encode_kwargs)
 
         input_file = tmp_path / "input.txt"
         input_file.write_text(content)
@@ -86,8 +90,6 @@ class TestRun:
         context, _ = self._run(tmp_path, "hello")
 
         _, kwargs = context.embedder.encode_document.call_args
-        assert "prompt" not in kwargs
-        assert "prompt_name" not in kwargs
         assert "truncate_dim" not in kwargs
         assert kwargs["normalize_embeddings"] is False
 
@@ -95,16 +97,13 @@ class TestRun:
         context, _ = self._run(
             tmp_path,
             "hello",
-            prompt="query: ",
             truncate_dim=128,
             normalize=True,
         )
 
         _, kwargs = context.embedder.encode_document.call_args
-        assert kwargs["prompt"] == "query: "
         assert kwargs["truncate_dim"] == 128
         assert kwargs["normalize_embeddings"] is True
-        assert "prompt_name" not in kwargs
 
     def test_output_written_as_npy(self, tmp_path):
         _, output_file = self._run(tmp_path, "hello world")

--- a/tests/unit/text/embed/test_embed.py
+++ b/tests/unit/text/embed/test_embed.py
@@ -1,0 +1,135 @@
+"""Unit tests for embed._base."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tigerflow_ml.text.embed._base import _EmbedBase
+from tigerflow_ml.utils import EmptyFileError
+
+
+def _make_context(**kwargs):
+    defaults = dict(
+        model="test-model",
+        revision="main",
+        cache_dir=None,
+        device="auto",
+        allow_fetch=False,
+        seed=42,
+        per_line=False,
+        batch_size=32,
+        prompt=None,
+        prompt_name=None,
+        normalize=False,
+        truncate_dim=None,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestSetup:
+    def test_prompt_and_prompt_name_mutually_exclusive(self):
+        context = _make_context(prompt="query: ", prompt_name="query")
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _EmbedBase.setup(context)
+
+    def test_model_not_found_without_allow_fetch_raises(self):
+        context = _make_context(allow_fetch=False)
+        with pytest.raises(RuntimeError, match="not found in cache"):
+            _EmbedBase.setup(context)
+
+
+class TestRun:
+    def _run(self, tmp_path, content, **context_kwargs):
+        context = _make_context(**context_kwargs)
+        context.embedder = MagicMock()
+        context.embedder.encode.return_value = np.zeros((3, 4))
+        context.embedder.encode_document.return_value = np.zeros(4)
+
+        input_file = tmp_path / "input.txt"
+        input_file.write_text(content)
+        output_file = tmp_path / "output.npy"
+
+        _EmbedBase.run(context, input_file, output_file)
+        return context, output_file
+
+    def test_unsupported_output_extension_raises(self, tmp_path):
+        context = _make_context()
+        context.embedder = MagicMock()
+        input_file = tmp_path / "input.txt"
+        input_file.write_text("hello")
+        output_file = tmp_path / "output.json"
+
+        with pytest.raises(ValueError, match="not a supported output"):
+            _EmbedBase.run(context, input_file, output_file)
+
+    def test_empty_file_raises(self, tmp_path):
+        context = _make_context()
+        context.embedder = MagicMock()
+        input_file = tmp_path / "input.txt"
+        input_file.write_text("   \n  ")
+        output_file = tmp_path / "output.npy"
+
+        with pytest.raises(EmptyFileError):
+            _EmbedBase.run(context, input_file, output_file)
+
+    def test_whole_file_uses_encode_document(self, tmp_path):
+        context, output_file = self._run(tmp_path, "hello world")
+
+        context.embedder.encode_document.assert_called_once()
+        context.embedder.encode.assert_not_called()
+        args, _ = context.embedder.encode_document.call_args
+        assert args[0] == "hello world"
+        assert output_file.exists()
+
+    def test_per_line_uses_encode_with_batch_size(self, tmp_path):
+        context, _ = self._run(
+            tmp_path,
+            "line one\n\nline two\n  \nline three",
+            per_line=True,
+            batch_size=8,
+        )
+
+        context.embedder.encode.assert_called_once()
+        context.embedder.encode_document.assert_not_called()
+        args, kwargs = context.embedder.encode.call_args
+        assert args[0] == ["line one", "line two", "line three"]
+        assert kwargs["batch_size"] == 8
+
+    def test_encode_kwargs_omit_unset_optional_fields(self, tmp_path):
+        context, _ = self._run(tmp_path, "hello")
+
+        _, kwargs = context.embedder.encode_document.call_args
+        assert "prompt" not in kwargs
+        assert "prompt_name" not in kwargs
+        assert "truncate_dim" not in kwargs
+        assert kwargs["normalize_embeddings"] is False
+
+    def test_encode_kwargs_include_set_optional_fields(self, tmp_path):
+        context, _ = self._run(
+            tmp_path,
+            "hello",
+            prompt="query: ",
+            truncate_dim=128,
+            normalize=True,
+        )
+
+        _, kwargs = context.embedder.encode_document.call_args
+        assert kwargs["prompt"] == "query: "
+        assert kwargs["truncate_dim"] == 128
+        assert kwargs["normalize_embeddings"] is True
+        assert "prompt_name" not in kwargs
+
+    def test_output_written_as_npy(self, tmp_path):
+        _, output_file = self._run(tmp_path, "hello world")
+
+        loaded = np.load(output_file)
+        assert loaded.shape == (4,)
+
+    def test_per_line_output_written_as_npy(self, tmp_path):
+        _, output_file = self._run(tmp_path, "one\ntwo\nthree", per_line=True)
+
+        loaded = np.load(output_file)
+        assert loaded.shape == (3, 4)

--- a/tests/unit/text/embed/test_params.py
+++ b/tests/unit/text/embed/test_params.py
@@ -3,9 +3,6 @@ from tigerflow_ml.text.embed._base import _EmbedBase
 
 def test_embed_defaults():
     p = _EmbedBase.Params()
-    assert p.per_line is False
-    assert p.batch_size == 32
-    assert p.prompt is None
-    assert p.prompt_name is None
     assert p.normalize is False
     assert p.truncate_dim is None
+    assert p.encode_kwargs == "{}"

--- a/tests/unit/text/embed/test_params.py
+++ b/tests/unit/text/embed/test_params.py
@@ -6,3 +6,4 @@ def test_embed_defaults():
     assert p.normalize is False
     assert p.truncate_dim is None
     assert p.encode_kwargs == "{}"
+    assert p.use_encode_document is False

--- a/tests/unit/text/embed/test_params.py
+++ b/tests/unit/text/embed/test_params.py
@@ -1,0 +1,11 @@
+from tigerflow_ml.text.embed._base import _EmbedBase
+
+
+def test_embed_defaults():
+    p = _EmbedBase.Params()
+    assert p.per_line is False
+    assert p.batch_size == 32
+    assert p.prompt is None
+    assert p.prompt_name is None
+    assert p.normalize is False
+    assert p.truncate_dim is None

--- a/uv.lock
+++ b/uv.lock
@@ -1700,6 +1700,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2305,6 +2314,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
     { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/66ed1fc6e38a0c0f330627ec5c5d597990d6159b6712b82af0ad2c65f06c/narwhals-2.23.0.tar.gz", hash = "sha256:13e7ff5b4bb4a2f77b907c2e4d8a76e273dfc1323a3c997440a2f9fd26aed408", size = 656209, upload-time = "2026-07-01T11:21:53.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/4e/afc8c31605cb8be1d3bb4438c4d979daa104dab6306cd2b87abe9c3a7299/narwhals-2.23.0-py3-none-any.whl", hash = "sha256:769e7b9ab102c93d8fa019f6b4cd1a657909b04a20bf6210e5a35aae06814ae9", size = 458938, upload-time = "2026-07-01T11:21:51.677Z" },
 ]
 
 [[package]]
@@ -4425,6 +4443,281 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/3e/daed796fd69cce768b8788401cc464ea90b306fb196ae1ffed0b98182859/scikit_learn-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b33579c10a3081d076ab403df4a4190da4f4432d443521674637677dc91e61f", size = 9336221, upload-time = "2025-09-09T08:20:19.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ce/af9d99533b24c55ff4e18d9b7b4d9919bbc6cd8f22fe7a7be01519a347d5/scikit_learn-1.7.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:36749fb62b3d961b1ce4fedf08fa57a1986cd409eff2d783bca5d4b9b5fce51c", size = 8653834, upload-time = "2025-09-09T08:20:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8", size = 9660938, upload-time = "2025-09-09T08:20:24.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/75/4311605069b5d220e7cf5adabb38535bd96f0079313cdbb04b291479b22a/scikit_learn-1.7.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a847fea807e278f821a0406ca01e387f97653e284ecbd9750e3ee7c90347f18", size = 9477818, upload-time = "2025-09-09T08:20:26.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9b/87961813c34adbca21a6b3f6b2bea344c43b30217a6d24cc437c6147f3e8/scikit_learn-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:ca250e6836d10e6f402436d6463d6c0e4d8e0234cfb6a9a47835bd392b852ce5", size = 8886969, upload-time = "2025-09-09T08:20:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/43/83/564e141eef908a5863a54da8ca342a137f45a0bfb71d1d79704c9894c9d1/scikit_learn-1.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7509693451651cd7361d30ce4e86a1347493554f172b1c72a39300fa2aea79e", size = 9331967, upload-time = "2025-09-09T08:20:32.421Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d6/ba863a4171ac9d7314c4d3fc251f015704a2caeee41ced89f321c049ed83/scikit_learn-1.7.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:0486c8f827c2e7b64837c731c8feff72c0bd2b998067a8a9cbc10643c31f0fe1", size = 8648645, upload-time = "2025-09-09T08:20:34.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89877e19a80c7b11a2891a27c21c4894fb18e2c2e077815bcade10d34287b20d", size = 9715424, upload-time = "2025-09-09T08:20:36.776Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/32/1f3b22e3207e1d2c883a7e09abb956362e7d1bd2f14458c7de258a26ac15/scikit_learn-1.7.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8da8bf89d4d79aaec192d2bda62f9b56ae4e5b4ef93b6a56b5de4977e375c1f1", size = 9509234, upload-time = "2025-09-09T08:20:38.957Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/71/34ddbd21f1da67c7a768146968b4d0220ee6831e4bcbad3e03dd3eae88b6/scikit_learn-1.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:9b7ed8d58725030568523e937c43e56bc01cadb478fc43c042a9aca1dacb3ba1", size = 8894244, upload-time = "2025-09-09T08:20:41.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/aa/3996e2196075689afb9fce0410ebdb4a09099d7964d061d7213700204409/scikit_learn-1.7.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d91a97fa2b706943822398ab943cde71858a50245e31bc71dba62aab1d60a96", size = 9259818, upload-time = "2025-09-09T08:20:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5d/779320063e88af9c4a7c2cf463ff11c21ac9c8bd730c4a294b0000b666c9/scikit_learn-1.7.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:acbc0f5fd2edd3432a22c69bed78e837c70cf896cd7993d71d51ba6708507476", size = 8636997, upload-time = "2025-09-09T08:20:45.468Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5bf3d930aee75a65478df91ac1225ff89cd28e9ac7bd1196853a9229b6adb0b", size = 9478381, upload-time = "2025-09-09T08:20:47.982Z" },
+    { url = "https://files.pythonhosted.org/packages/82/70/8bf44b933837ba8494ca0fc9a9ab60f1c13b062ad0197f60a56e2fc4c43e/scikit_learn-1.7.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4d6e9deed1a47aca9fe2f267ab8e8fe82ee20b4526b2c0cd9e135cea10feb44", size = 9300296, upload-time = "2025-09-09T08:20:50.366Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/99/ed35197a158f1fdc2fe7c3680e9c70d0128f662e1fee4ed495f4b5e13db0/scikit_learn-1.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:6088aa475f0785e01bcf8529f55280a3d7d298679f50c0bb70a2364a82d0b290", size = 8731256, upload-time = "2025-09-09T08:20:52.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
+    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ab/5cc9f80f28f6a7dff646c5756e559823614a42b1939d86dd0ed550470210/scipy-1.15.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:993439ce220d25e3696d1b23b233dd010169b62f6456488567e830654ee37a6b", size = 38714255, upload-time = "2025-05-08T16:05:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035, upload-time = "2025-05-08T16:05:20.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499, upload-time = "2025-05-08T16:05:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/f3aaddccf3588bb4aea70ba35328c204cadd89517a1612ecfda5b2dd9d7a/scipy-1.15.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:6db907c7368e3092e24919b5e31c76998b0ce1684d51a90943cb0ed1b4ffd6c1", size = 25152602, upload-time = "2025-05-08T16:05:29.313Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/1032cdb565f146109212153339f9cb8b993701e9fe56b1c97699eee12586/scipy-1.15.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721d6b4ef5dc82ca8968c25b111e307083d7ca9091bc38163fb89243e85e3889", size = 35503415, upload-time = "2025-05-08T16:05:34.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/37/89f19c8c05505d0601ed5650156e50eb881ae3918786c8fd7262b4ee66d3/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39cb9c62e471b1bb3750066ecc3a3f3052b37751c7c3dfd0fd7e48900ed52982", size = 37652622, upload-time = "2025-05-08T16:05:40.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/be59513aa9695519b18e1851bb9e487de66f2d31f835201f1b42f5d4d475/scipy-1.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:795c46999bae845966368a3c013e0e00947932d68e235702b5c3f6ea799aa8c9", size = 37244796, upload-time = "2025-05-08T16:05:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c0/4f5f3eeccc235632aab79b27a74a9130c6c35df358129f7ac8b29f562ac7/scipy-1.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18aaacb735ab38b38db42cb01f6b92a2d0d4b6aabefeb07f02849e47f8fb3594", size = 40047684, upload-time = "2025-05-08T16:05:54.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a7/0ddaf514ce8a8714f6ed243a2b391b41dbb65251affe21ee3077ec45ea9a/scipy-1.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:ae48a786a28412d744c62fd7816a4118ef97e5be0bee968ce8f0a2fba7acf3bb", size = 41246504, upload-time = "2025-05-08T16:06:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/ec27848c9baae6e0d6573eda6e01a602e5649ee72c27c3a8aad673ebecfd/scipy-1.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c620736bcc334782e24d173c0fdbb7590a0a436d2fdf39310a8902505008759", size = 38728256, upload-time = "2025-05-08T16:06:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/1aef2184948728b4b6e21267d53b3339762c285a46a274ebb7863c9e4742/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7e11270a000969409d37ed399585ee530b9ef6aa99d50c019de4cb01e8e54e62", size = 30109540, upload-time = "2025-05-08T16:07:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d8/59e452c0a255ec352bd0a833537a3bc1bfb679944c4938ab375b0a6b3a3e/scipy-1.15.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8c9ed3ba2c8a2ce098163a9bdb26f891746d02136995df25227a20e71c396ebb", size = 22383115, upload-time = "2025-05-08T16:07:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/456f56bbbfccf696263b47095291040655e3cbaf05d063bdc7c7517f32ac/scipy-1.15.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0bdd905264c0c9cfa74a4772cdb2070171790381a5c4d312c973382fc6eaf730", size = 25163884, upload-time = "2025-05-08T16:07:14.091Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/66/a9618b6a435a0f0c0b8a6d0a2efb32d4ec5a85f023c2b79d39512040355b/scipy-1.15.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79167bba085c31f38603e11a267d862957cbb3ce018d8b38f79ac043bc92d825", size = 35174018, upload-time = "2025-05-08T16:07:19.427Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/c5b6734a50ad4882432b6bb7c02baf757f5b2f256041da5df242e2d7e6b6/scipy-1.15.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9deabd6d547aee2c9a81dee6cc96c6d7e9a9b1953f74850c179f91fdc729cb7", size = 37269716, upload-time = "2025-05-08T16:07:25.712Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0a/eac00ff741f23bcabd352731ed9b8995a0a60ef57f5fd788d611d43d69a1/scipy-1.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dde4fc32993071ac0c7dd2d82569e544f0bdaff66269cb475e0f369adad13f11", size = 36872342, upload-time = "2025-05-08T16:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/4379be86dd74b6ad81551689107360d9a3e18f24d20767a2d5b9253a3f0a/scipy-1.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f77f853d584e72e874d87357ad70f44b437331507d1c311457bed8ed2b956126", size = 39670869, upload-time = "2025-05-08T16:07:38.002Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/892ad2862ba54f084ffe8cc4a22667eaf9c2bcec6d2bff1d15713c6c0703/scipy-1.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:b90ab29d0c37ec9bf55424c064312930ca5f4bde15ee8619ee44e69319aab163", size = 40988851, upload-time = "2025-05-08T16:08:33.671Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e9/7a879c137f7e55b30d75d90ce3eb468197646bc7b443ac036ae3fe109055/scipy-1.15.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3ac07623267feb3ae308487c260ac684b32ea35fd81e12845039952f558047b8", size = 38863011, upload-time = "2025-05-08T16:07:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d1/226a806bbd69f62ce5ef5f3ffadc35286e9fbc802f606a07eb83bf2359de/scipy-1.15.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6487aa99c2a3d509a5227d9a5e889ff05830a06b2ce08ec30df6d79db5fcd5c5", size = 30266407, upload-time = "2025-05-08T16:07:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9b/f32d1d6093ab9eeabbd839b0f7619c62e46cc4b7b6dbf05b6e615bbd4400/scipy-1.15.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:50f9e62461c95d933d5c5ef4a1f2ebf9a2b4e83b0db374cb3f1de104d935922e", size = 22540030, upload-time = "2025-05-08T16:07:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/29/c278f699b095c1a884f29fda126340fcc201461ee8bfea5c8bdb1c7c958b/scipy-1.15.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:14ed70039d182f411ffc74789a16df3835e05dc469b898233a245cdfd7f162cb", size = 25218709, upload-time = "2025-05-08T16:07:58.506Z" },
+    { url = "https://files.pythonhosted.org/packages/24/18/9e5374b617aba742a990581373cd6b68a2945d65cc588482749ef2e64467/scipy-1.15.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a769105537aa07a69468a0eefcd121be52006db61cdd8cac8a0e68980bbb723", size = 34809045, upload-time = "2025-05-08T16:08:03.929Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fe/9c4361e7ba2927074360856db6135ef4904d505e9b3afbbcb073c4008328/scipy-1.15.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9db984639887e3dffb3928d118145ffe40eff2fa40cb241a306ec57c219ebbbb", size = 36703062, upload-time = "2025-05-08T16:08:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132, upload-time = "2025-05-08T16:08:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503, upload-time = "2025-05-08T16:08:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097, upload-time = "2025-05-08T16:08:27.627Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/d2cb00765a6b15c994a7fccf20f9032f16e8193ca49147cb5155166ad744/sentence_transformers-5.6.0.tar.gz", hash = "sha256:0e7164d051e416c1853ade7c274ff52af3f9da0f4be7f0b83d734c27699e1057", size = 453194, upload-time = "2026-06-16T14:01:56.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c1/dc1582b79e9a2eb0cddf9559cd9bcdff084f541d6fe881fdd9d98630dba7/sentence_transformers-5.6.0-py3-none-any.whl", hash = "sha256:d2075b5e687a1611005e20ab04a6846994d51adfcf39610aed066af3c0c0b81f", size = 596411, upload-time = "2026-06-16T14:01:55.103Z" },
+]
+
+[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4711,6 +5004,15 @@ wheels = [
 ]
 
 [[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
 name = "tigerflow"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4742,6 +5044,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "pymupdf" },
+    { name = "sentence-transformers" },
     { name = "sentencepiece" },
     { name = "soundfile" },
     { name = "soxr" },
@@ -4788,6 +5091,7 @@ requires-dist = [
     { name = "protobuf" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pymupdf", specifier = ">=1.27.1" },
+    { name = "sentence-transformers", specifier = ">=5.6.0" },
     { name = "sentencepiece" },
     { name = "soundfile", specifier = ">=0.12" },
     { name = "soxr", specifier = ">=0.3" },


### PR DESCRIPTION
Adds an initial implementation of an `embed` task (currently only supports text inputs and `.npy` outputs)

Tested with `sentence-transformers/all-MiniLM-L6-v2`

### Deferred 
- [x] Support image inputs (#180)
- [x] Support audio inputs (#181)
- [x] Support video inputs
- [ ] Support saving embedding to json output
- [x] Integration tests

### Open design question
This task does not fall neatly into the `text` grouping -- it will support all input types and outputs embeddings; it seems like the task should not live in a sub-folder?
