### PR TITLE
feat(embed): add support for img and pdf inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install tigerflow-ml[vllm]
 | Chat             | Apply a chat prompt to text, images, audio, or video | `chat` / `chat-local`             |
 | Transcription    | Transcribe audio to text              | `transcribe` / `transcribe-local` |
 | Object Detection | Detect objects in images and videos   | `detect` / `detect-local`         |
-| Embed            | Embed text documents                  | `embed` / `embed-local`           |
+| Embed            | Embed text or images                  | `embed` / `embed-local`           |
 
 Each task provides both a Slurm variant (for HPC) and a Local variant (for development).
 

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -40,7 +40,7 @@ hide:
 - [Transcription](tasks/transcribe.md) — Transcribe audio to text
 - [Object Detection](tasks/detect.md) — Detect objects in images and videos
 - [Chat](tasks/chat.md) - Apply a chat prompt to text, image, audio, or video documents
-- [Embed](tasks/embed.md) - Embed text using HuggingFace sentence-transformers models
+- [Embed](tasks/embed.md) — Embed text or images
 
 ## Installation
 

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -1,6 +1,6 @@
 # Embed
 
-Embed text using HuggingFace sentence-transformers models.
+Embed text or images using HuggingFace sentence-transformers models.
 
 ## Parameters
 
@@ -13,6 +13,7 @@ Embed text using HuggingFace sentence-transformers models.
 | `--allow-fetch`     | `--no-allow-fetch` | Allow downloads from HuggingFace Hub (network access required)                                                     |
 | `--seed`            | `42`               | The seed to set for more reproducible behavior                                                                     |
 | `--encode-kwargs`   | `{}`               | Additional kwargs for SentenceTransformer's `encode()` (e.g. `{'prompt':'query: '}`). Supplied values override task defaults. |
+| `--batch-size`      | `32`               | Number of pages per batch when embedding a multi-page PDF                                                          |
 | `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
 | `--truncate-dim`    |                    | The dimension to truncate sentence embeddings to                                                                   |
 | `--use-encode-document` | `--no-use-encode-document` | Use SentenceTransformer's `encode_document()` instead of `encode()`. See [SentenceTransformer's documentation](https://sbert.net/docs/package_reference/sentence_transformer/model.html#sentence_transformers.sentence_transformer.model.SentenceTransformer.encode_document) for more information. |
@@ -21,15 +22,20 @@ Embed text using HuggingFace sentence-transformers models.
 
 ## Supported Input Formats
 
-Text files (`.txt`, `.text`, `.md`, `.log`, `.rtf`)
+- Text files (`.txt`, `.text`, `.md`, `.log`, `.rtf`)
+- Image files (`.jpg`, `.jpeg`, `.png`, `.tiff`, `.tif`, `.bmp`, `.heic`, `.heif`)
+- PDF files (`.pdf`) — each page is rendered to an image and embedded
 
 ## Output Format
 
 NumPy binary (`.npy`).
 
+- A single image (or single-page PDF) produces a 1-D array of shape `(dim,)`.
+- A multi-page PDF produces a 2-D array of shape `(n_pages, dim)`, one row per page.
+
 ## Models
 
-Any HuggingFace model compatible with the [sentence-transformers](https://sbert.net) library, including plain encoder models.
+Any HuggingFace model compatible with the [sentence-transformers](https://sbert.net) library, including plain text encoder models. Embedding image or PDF input requires a multi-modal model (e.g. CLIP-style) that supports image encoding.
 
 ## Examples
 
@@ -58,6 +64,33 @@ Any HuggingFace model compatible with the [sentence-transformers](https://sbert.
 === "Output (.npy)"
 
     A single vector of shape `(384,)`.
+
+### Embed an image
+
+Use a multi-modal (CLIP-style) model to embed images. PDFs are supported the same
+way, with one row of output per page.
+
+=== "Config"
+
+    ```yaml title="config.yaml"
+    tasks:
+      - name: embed
+        kind: local
+        module: tigerflow_ml.text.embed.local
+        input_ext: .jpg
+        output_ext: .npy
+        params:
+          model: sentence-transformers/clip-ViT-B-32
+          allow-fetch: True
+    ```
+
+=== "Input"
+
+    An image file, e.g. `photo.jpg`.
+
+=== "Output (.npy)"
+
+    A single vector of shape `(512,)`.
 
 ### Run on HPC with Slurm
 

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -109,6 +109,8 @@ tasks:
       gpus: 1
       memory: 16G
       time: 04:00:00
+    setup_commands:
+      - export HF_HUB_OFFLINE=1
     params:
       model: BAAI/bge-base-en-v1.5
       encode-kwargs: {"prompt":"query: "}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "soundfile>=0.12",
     "soxr>=0.3",
     "pillow-heif>=1.4.0",
-    "sentence-transformers>=5.6.0",
+    "sentence-transformers[image]>=5.6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -83,7 +83,7 @@ class _EmbedBase:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
         torch.manual_seed(context.seed)
-
+        logger.info(f"   Loading model {context.model}...")
         try:
             context.embedder = SentenceTransformer(
                 context.model,
@@ -91,6 +91,7 @@ class _EmbedBase:
                 cache_folder=context.cache_dir,
                 device=device,
                 local_files_only=not context.allow_fetch,
+                trust_remote_code=True,
             )
         except OSError as e:
             if not context.allow_fetch:

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -7,7 +7,15 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
-from tigerflow_ml.utils import TEXT_EXTENSIONS, parse_kwargs, read_text_file_strict
+from tigerflow_ml.utils import (
+    IMG_EXTENSIONS,
+    TEXT_EXTENSIONS,
+    load_images,
+    parse_kwargs,
+    read_text_file_strict,
+)
+
+_TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 
 
 class _EmbedBase:
@@ -108,6 +116,14 @@ class _EmbedBase:
                 context=context,
                 input_file=input_file,
             )
+        elif (
+            input_file.suffix.lower() in IMG_EXTENSIONS
+            and input_file.suffix.lower() != ".pdf"
+        ):
+            embeddings = _EmbedBase._embed_image(
+                context=context,
+                input_file=input_file,
+            )
         else:
             raise ValueError(
                 f"File extension {input_file.suffix} not currently supported - "
@@ -129,3 +145,10 @@ class _EmbedBase:
             embeddings = context.embedder.encode(content, **context.encode_kwargs)
         logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
         return embeddings
+
+    @staticmethod
+    def _embed_image(context: SetupContext, input_file: Path):
+        image = next(load_images(path=input_file, max_images=1))
+        embedding = context.embedder.encode(image, **context.encode_kwargs)
+        logger.info(f"   Embedded image with shape {embedding.shape}")
+        return embedding

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -10,12 +10,13 @@ from tigerflow_ml.params import HFParams
 from tigerflow_ml.utils import (
     IMG_EXTENSIONS,
     TEXT_EXTENSIONS,
+    EmptyFileError,
+    batched,
+    count_images,
     load_images,
     parse_kwargs,
     read_text_file_strict,
 )
-
-_TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 
 
 class _EmbedBase:
@@ -57,6 +58,15 @@ class _EmbedBase:
                 "(e.g., {'prompt':'query: '}). Supplied values override task defaults."
             ),
         ] = "{}"
+
+        batch_size: Annotated[
+            int,
+            typer.Option(
+                help="The number of pages to encode in one batch if encoding"
+                "multi-page pdfs as images",
+                min=1,
+            ),
+        ] = 100
 
     @staticmethod
     def setup(context: SetupContext):
@@ -116,10 +126,7 @@ class _EmbedBase:
                 context=context,
                 input_file=input_file,
             )
-        elif (
-            input_file.suffix.lower() in IMG_EXTENSIONS
-            and input_file.suffix.lower() != ".pdf"
-        ):
+        elif input_file.suffix.lower() in IMG_EXTENSIONS:
             embeddings = _EmbedBase._embed_image(
                 context=context,
                 input_file=input_file,
@@ -148,7 +155,19 @@ class _EmbedBase:
 
     @staticmethod
     def _embed_image(context: SetupContext, input_file: Path):
-        image = next(load_images(path=input_file, max_images=1))
-        embedding = context.embedder.encode(image, **context.encode_kwargs)
-        logger.info(f"   Embedded image with shape {embedding.shape}")
-        return embedding
+        total = count_images(input_file)
+        if total == 0:
+            raise EmptyFileError(f"{input_file} is empty")
+        if total == 1:
+            image = next(load_images(input_file))
+            embeddings = context.embedder.encode(image, **context.encode_kwargs)
+            logger.info(f"   Embedded image with shape {embeddings.shape}")
+        else:  # multi-page
+            embeddings = np.concatenate(
+                [
+                    context.embedder.encode(batch, **context.encode_kwargs)
+                    for batch in batched(load_images(input_file), context.batch_size)
+                ]
+            )
+            logger.info(f"   Embedded {total} page(s) with shape {embeddings.shape}")
+        return embeddings

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -66,7 +66,7 @@ class _EmbedBase:
                 "multi-page pdfs as images",
                 min=1,
             ),
-        ] = 100
+        ] = 32
 
     @staticmethod
     def setup(context: SetupContext):

--- a/uv.lock
+++ b/uv.lock
@@ -4717,6 +4717,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ad/8f73f512dc7ad4031d2b64cbb67f70bdfb355756afbe0db610a5146415c1/sentence_transformers-5.6.1-py3-none-any.whl", hash = "sha256:cefbb17b6325a982a4732c8c49fb013375392687049d1de3d435c4b04060680b", size = 596677, upload-time = "2026-07-23T14:40:40.312Z" },
 ]
 
+[package.optional-dependencies]
+image = [
+    { name = "transformers", extra = ["vision"] },
+]
+
 [[package]]
 name = "sentencepiece"
 version = "0.2.2"
@@ -5039,7 +5044,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "pymupdf" },
-    { name = "sentence-transformers" },
+    { name = "sentence-transformers", extra = ["image"] },
     { name = "sentencepiece" },
     { name = "soundfile" },
     { name = "soxr" },
@@ -5086,7 +5091,7 @@ requires-dist = [
     { name = "protobuf" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pymupdf", specifier = ">=1.27.1" },
-    { name = "sentence-transformers", specifier = ">=5.6.0" },
+    { name = "sentence-transformers", extras = ["image"], specifier = ">=5.6.0" },
     { name = "sentencepiece" },
     { name = "soundfile", specifier = ">=0.12" },
     { name = "soxr", specifier = ">=0.3" },
@@ -5493,6 +5498,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/51/58/7f843608f2e8421f86bb97060b54649be6239ec612b82bf9d41e65c26c00/transformers-5.9.0.tar.gz", hash = "sha256:25997cb8fa6053533171634b6162d7df54346530ec2aa9b42bb834e63668c842", size = 8642240, upload-time = "2026-05-20T14:50:49.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/ca/2eaa5359f2ccb8c2e1656bc26305ad0cf438aa392ce4b29ae67a315c186e/transformers-5.9.0-py3-none-any.whl", hash = "sha256:1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788", size = 10787648, upload-time = "2026-05-20T14:50:45.337Z" },
+]
+
+[package.optional-dependencies]
+vision = [
+    { name = "pillow" },
+    { name = "torchvision" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds support for image and pdf inputs to the embed task. For pdfs, each page is embedded as an image. 

Tested with `sentence-transformers/clip-ViT-B-32`

Ref #3 