### PR TITLE
feat(embed): add support for video inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install tigerflow-ml[vllm]
 | Chat             | Apply a chat prompt to images or text | `chat` / `chat-local`             |
 | Transcription    | Transcribe audio to text              | `transcribe` / `transcribe-local` |
 | Object Detection | Detect objects in images and videos   | `detect` / `detect-local`         |
-| Embed            | Embed text, images, or audio          | `embed` / `embed-local`           |
+| Embed            | Embed text, images, audio, or video   | `embed` / `embed-local`           |
 
 Each task provides both a Slurm variant (for HPC) and a Local variant (for development).
 

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -40,7 +40,7 @@ hide:
 - [Transcription](tasks/transcribe.md) — Transcribe audio to text
 - [Object Detection](tasks/detect.md) — Detect objects in images and videos
 - [Chat](tasks/chat.md) - Apply a chat prompt to text or image documents
-- [Embed](tasks/embed.md) — Embed text, images, or audio
+- [Embed](tasks/embed.md) — Embed text, images, audio, or video
 
 ## Installation
 

--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -1,6 +1,6 @@
 # Embed
 
-Embed text, images, or audio using HuggingFace sentence-transformers models.
+Embed text, images, audio, or video using HuggingFace sentence-transformers models.
 
 ## Parameters
 
@@ -13,7 +13,8 @@ Embed text, images, or audio using HuggingFace sentence-transformers models.
 | `--allow-fetch`     | `--no-allow-fetch` | Allow downloads from HuggingFace Hub (network access required)                                                     |
 | `--seed`            | `42`               | The seed to set for more reproducible behavior                                                                     |
 | `--per-line`        | `--no-per-line`    | Embed each non-empty line of the input file independently, producing one vector per line instead of a single vector for the whole file (text input only) |
-| `--batch-size`      | `32`               | Number of lines encoded per batch when `--per-line` is set, or number of pages per batch when embedding a multi-page PDF |
+| `--batch-size`      | `32`               | Number of lines encoded per batch when `--per-line` is set, number of pages per batch for a multi-page PDF, or number of frames per batch for video |
+| `--sample-fps`      | `1.0`              | Frames per second to sample from video. Set to `0` to process every frame (video input only) |
 | `--prompt`          |                    | Raw text prepended to each input before encoding (e.g. `query: `). Mutually exclusive with `--prompt-name`         |
 | `--prompt-name`     |                    | Name of a prompt predefined in the model's config (e.g. `query` or `passage` for e5/bge models). Mutually exclusive with `--prompt` |
 | `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
@@ -26,6 +27,8 @@ Embed text, images, or audio using HuggingFace sentence-transformers models.
 - PDF files (`.pdf`) — each page is rendered to an image and embedded
 - Audio files (`.wav`, `.flac`, `.ogg`, `.aiff`, `.aif`, `.mp3`) — decoded, averaged to
   mono, and resampled to the rate the model expects
+- Video files (`.mp4`, `.avi`, `.mov`, `.mkv`, `.webm`, `.flv`, `.wmv`) — sampled to
+  frames at `--sample-fps` and each frame is embedded
 
 ## Output Format
 
@@ -36,10 +39,11 @@ NumPy binary (`.npy`).
 - A single image (or single-page PDF) produces a 1-D array of shape `(dim,)`.
 - A multi-page PDF produces a 2-D array of shape `(n_pages, dim)`, one row per page.
 - A single audio file produces a 1-D array of shape `(dim,)`.
+- A video producing more than one sampled frame outputs a 2-D array of shape `(n_frames, dim)`, one row per frame; a video that samples down to a single frame outputs a 1-D array of shape `(dim,)`.
 
 ## Models
 
-Any HuggingFace model compatible with the [sentence-transformers](https://sbert.net) library, including plain text encoder models. Embedding image or PDF input requires a multi-modal model (e.g. CLIP-style) that supports image encoding. Embedding audio requires an audio-capable model (e.g. `wav2vec2`, `HuBERT`, `WavLM`, a Whisper encoder, or CLAP) — the audio is automatically resampled to whatever rate that model's feature extractor expects.
+Any HuggingFace model compatible with the [sentence-transformers](https://sbert.net) library, including plain text encoder models works for text input. Embedding image or PDF input requires a multi-modal model (e.g. CLIP-style) that supports image encoding. Video is embedded as a sequence of sampled frames through the same image-capable models used for image input — there's no dedicated "video model" requirement, so any CLIP-style model works, at the cost of not modeling motion/temporal information across frames. Embedding audio requires an audio-capable model (e.g. `wav2vec2`, `HuBERT`, `WavLM`, a Whisper encoder, or CLAP) — the audio is automatically resampled to whatever rate that model's feature extractor expects.
 
 ## Examples
 
@@ -154,6 +158,35 @@ mono, and resampled to the model's expected sampling rate before encoding.
 === "Output (.npy)"
 
     A single vector of shape `(384,)`.
+
+### Embed video
+
+Video is sampled to frames at `--sample-fps` and each frame is embedded with the same
+multi-modal model used for images.
+
+=== "Config"
+
+    ```yaml title="config.yaml"
+    tasks:
+      - name: embed
+        kind: local
+        module: tigerflow_ml.text.embed.local
+        input_ext: .mp4
+        output_ext: .npy
+        params:
+          model: sentence-transformers/clip-ViT-B-32
+          sample-fps: 1.0
+          allow-fetch: True
+    ```
+
+=== "Input"
+
+    A video file, e.g. `clip.mp4` (roughly 30 seconds).
+
+=== "Output (.npy)"
+
+    An array of shape `(31, 512)` — one row per sampled frame (`--sample-fps 1.0`
+    samples roughly one frame per second of video).
 
 ### Run on HPC with Slurm
 

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import numpy as np
 import typer
@@ -14,8 +14,12 @@ from tigerflow_ml.utils import (
     read_text_file_strict,
 )
 
+if TYPE_CHECKING:
+    from PIL import Image
+
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _AUDIO_EXTENSIONS = [".wav", ".flac", ".ogg", ".aiff", ".aif", ".mp3"]
+_VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"]
 
 
 class _EmbedBase:
@@ -35,10 +39,20 @@ class _EmbedBase:
             int,
             typer.Option(
                 help="Number of lines encoded per batch when --per-line is set, "
-                "or number of pages per batch if embedding pdfs",
+                "number of pages per batch if embedding pdfs, or number of "
+                "frames if embedding videos",
                 min=1,
             ),
         ] = 32
+
+        sample_fps: Annotated[
+            float,
+            typer.Option(
+                help="Frames per second to sample from video. "
+                "Set to 0 to process every frame.",
+                min=0,
+            ),
+        ] = 1.0
 
         prompt: Annotated[
             str | None,
@@ -134,6 +148,10 @@ class _EmbedBase:
             embeddings = _EmbedBase._embed_audio(
                 context=context, input_file=input_file, encode_kwargs=encode_kwargs
             )
+        elif input_file.suffix.lower() in _VIDEO_EXTENSIONS:
+            embeddings = _EmbedBase._embed_video(
+                context=context, input_file=input_file, encode_kwargs=encode_kwargs
+            )
         else:
             raise ValueError(
                 f"File extension {input_file.suffix} not currently supported - "
@@ -204,6 +222,26 @@ class _EmbedBase:
         )
         return embeddings
 
+    @staticmethod
+    def _embed_video(
+        context: SetupContext, input_file: Path, encode_kwargs: dict[str, Any]
+    ):
+        video_frames = load_video_frames(input_file, sample_fps=context.sample_fps)
+        if len(video_frames) == 0:
+            raise EmptyFileError(f"No frames extracted from {input_file}")
+        if len(video_frames) == 1:
+            logger.warning(f"Only one frame extracted from {input_file}")
+            embeddings = context.embedder.encode(video_frames[0], **encode_kwargs)
+        else:
+            embeddings = context.embedder.encode(
+                video_frames, batch_size=context.batch_size, **encode_kwargs
+            )
+
+        logger.info(
+            f"   Embedded {len(video_frames)} frame(s) with shape {embeddings.shape}"
+        )
+        return embeddings
+
 
 def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
     """Delete once PR #176 merged (will be in shared utils)"""
@@ -216,3 +254,44 @@ def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
     if sr != sampling_rate:
         array = soxr.resample(array, sr, sampling_rate)
     return np.ascontiguousarray(array, dtype=np.float32)
+
+
+def load_video_frames(video_path: Path, sample_fps: float) -> list["Image.Image"]:
+    import math
+
+    import cv2
+    from PIL import Image
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        msg = f"Could not open video: {video_path}"
+        raise ValueError(msg)
+    try:
+        video_fps = cap.get(cv2.CAP_PROP_FPS)
+        if not video_fps or math.isnan(video_fps):
+            msg = f"Could not determine FPS for video: {video_path}"
+            raise ValueError(msg)
+        if sample_fps > 0:
+            if sample_fps > video_fps:
+                logger.warning(
+                    f"Requested sample_fps ({sample_fps}) exceeds video fps "
+                    f"({video_fps:.2f}); sampling every frame."
+                )
+            frame_interval = max(1, int(video_fps / sample_fps))
+        else:
+            frame_interval = 1
+        frame_num = 0
+        frames = []
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            if frame_num % frame_interval == 0:
+                rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                frames.append(Image.fromarray(rgb))
+
+            frame_num += 1
+    finally:
+        cap.release()
+    return frames

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -1,3 +1,5 @@
+import math
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -15,7 +17,8 @@ from tigerflow_ml.utils import (
 )
 
 if TYPE_CHECKING:
-    from PIL import Image
+    from PIL import Image as PILImage
+
 
 _TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
 _AUDIO_EXTENSIONS = [".wav", ".flac", ".ogg", ".aiff", ".aif", ".mp3"]
@@ -226,19 +229,19 @@ class _EmbedBase:
     def _embed_video(
         context: SetupContext, input_file: Path, encode_kwargs: dict[str, Any]
     ):
-        video_frames = load_video_frames(input_file, sample_fps=context.sample_fps)
-        if len(video_frames) == 0:
-            raise EmptyFileError(f"No frames extracted from {input_file}")
-        if len(video_frames) == 1:
-            logger.warning(f"Only one frame extracted from {input_file}")
-            embeddings = context.embedder.encode(video_frames[0], **encode_kwargs)
-        else:
-            embeddings = context.embedder.encode(
-                video_frames, batch_size=context.batch_size, **encode_kwargs
-            )
 
+        embeddings = []
+
+        for batch in _batched(
+            _iter_frames(input_file, context.sample_fps), context.batch_size
+        ):
+            images = [img for _, _, img in batch]
+            logger.info(f"      Embedding {len(images)} frames...")
+            embedding = context.embedder.encode(images, **encode_kwargs)
+            embeddings.append(embedding)
+        embeddings = np.vstack(embeddings)
         logger.info(
-            f"   Embedded {len(video_frames)} frame(s) with shape {embeddings.shape}"
+            f"   Embedded {embeddings.shape[0]} frame(s) with shape {embeddings.shape}"
         )
         return embeddings
 
@@ -256,9 +259,22 @@ def load_audio(input_file: Path, sampling_rate: int = 16000) -> np.ndarray:
     return np.ascontiguousarray(array, dtype=np.float32)
 
 
-def load_video_frames(video_path: Path, sample_fps: float) -> list["Image.Image"]:
-    import math
+def _batched(iterable: Iterator, n: int) -> Iterator[list]:
+    """Yield successive lists of up to n items from iterable."""
+    batch: list = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) == n:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
 
+
+def _iter_frames(
+    video_path: Path, sample_fps: float
+) -> Iterator[tuple[int, float, "PILImage.Image"]]:
+    """Yield (frame_number, timestamp_seconds, PIL.Image) sampled from a video."""
     import cv2
     from PIL import Image
 
@@ -266,11 +282,13 @@ def load_video_frames(video_path: Path, sample_fps: float) -> list["Image.Image"
     if not cap.isOpened():
         msg = f"Could not open video: {video_path}"
         raise ValueError(msg)
+
     try:
         video_fps = cap.get(cv2.CAP_PROP_FPS)
         if not video_fps or math.isnan(video_fps):
             msg = f"Could not determine FPS for video: {video_path}"
             raise ValueError(msg)
+
         if sample_fps > 0:
             if sample_fps > video_fps:
                 logger.warning(
@@ -280,18 +298,18 @@ def load_video_frames(video_path: Path, sample_fps: float) -> list["Image.Image"
             frame_interval = max(1, int(video_fps / sample_fps))
         else:
             frame_interval = 1
+
         frame_num = 0
-        frames = []
         while True:
             ret, frame = cap.read()
             if not ret:
                 break
 
             if frame_num % frame_interval == 0:
+                timestamp = frame_num / video_fps
                 rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                frames.append(Image.fromarray(rgb))
+                yield (frame_num, timestamp, Image.fromarray(rgb))
 
             frame_num += 1
     finally:
         cap.release()
-    return frames


### PR DESCRIPTION
Adds support for embedding videos on a frame-by-frame level. Instead of embedding the whole video using specialized models, any multimodal that supports image encoding can be used to embed individual frames from the input video. This appears to be a common practice, though misses temporal feature extraction. 

Ideally, it would be nice to also have support for models especially designed for video processing, though it seems the implementation details vary depending on the model. It could be possible though to have some logic similar to that in the `translate` task, and support specific model families. 

Tested with `sentence-transformers/clip-ViT-B-32` on `mp4`

Ref #3 