### PR TITLE
fix: update load_images() to return an iterator

### DIFF
--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -18,7 +18,7 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 | `--sampling-kwargs` | `{}`                        | Additional kwargs for vLLM's SamplingParams() constructor. Supplied values override task defaults. |
 | `--chat-kwargs`   | `{}`                          | Additional kwargs for vLLM's LLM.chat(). Supplied values override task defaults.                   |
 | `--prompt`        |                               | Prompt for image-text-to-text models                                                               |
-| `--batch-size`    | `20`                          | Number of PDF pages sent to the model per chat() call. Bounds peak memory for large, multi-page PDFs; higher values use more memory. |
+| `--buffer-size`   | `100`                         | Number of PDF pages loaded in memory at a time. Bounds peak memory for large, multi-page PDFs; higher values use more memory. |
 | `--json-schema`   |                               | Constrain the model's output to a JSON schema using vllm structured outputs. Provide the schema as a JSON string, e.g. `{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}`. Requires a model that supports structured outputs. |
 
 

--- a/docs/mkdocs/tasks/ocr.md
+++ b/docs/mkdocs/tasks/ocr.md
@@ -18,6 +18,7 @@ Extract text from images and PDFs using HuggingFace image-text-to-text models.
 | `--sampling-kwargs` | `{}`                        | Additional kwargs for vLLM's SamplingParams() constructor. Supplied values override task defaults. |
 | `--chat-kwargs`   | `{}`                          | Additional kwargs for vLLM's LLM.chat(). Supplied values override task defaults.                   |
 | `--prompt`        |                               | Prompt for image-text-to-text models                                                               |
+| `--batch-size`    | `20`                          | Number of PDF pages sent to the model per chat() call. Bounds peak memory for large, multi-page PDFs; higher values use more memory. |
 | `--json-schema`   |                               | Constrain the model's output to a JSON schema using vllm structured outputs. Provide the schema as a JSON string, e.g. `{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}`. Requires a model that supports structured outputs. |
 
 

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -23,6 +23,7 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
+from tigerflow_ml.utils import batched
 
 _VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
 
@@ -284,7 +285,7 @@ def _run_video_batched(context: SetupContext, input_file: Path) -> list[_FramedO
     device = model.device
 
     output: list[_FramedOutput] = []
-    for batch in _batched(
+    for batch in batched(
         _iter_frames(input_file, context.sample_fps), context.batch_size
     ):
         images = [img for _, _, img in batch]
@@ -336,18 +337,6 @@ def _box_to_dict(box) -> dict:
         "xmax": round(xmax),
         "ymax": round(ymax),
     }
-
-
-def _batched(iterable: Iterator, n: int) -> Iterator[list]:
-    """Yield successive lists of up to n items from iterable."""
-    batch: list = []
-    for item in iterable:
-        batch.append(item)
-        if len(batch) == n:
-            yield batch
-            batch = []
-    if batch:
-        yield batch
 
 
 def _iter_frames(

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -63,13 +63,13 @@ class _OCRBase:
             ),
         ] = None
 
-        batch_size: Annotated[
+        buffer_size: Annotated[
             int,
             typer.Option(
-                help="Number of PDF pages sent to the model per chat() call.",
+                help="Number of PDF pages loaded in memory as images at one time",
                 min=1,
             ),
-        ] = 20
+        ] = 100
 
     @staticmethod
     def setup(context: SetupContext):
@@ -142,7 +142,7 @@ class _OCRBase:
         total = count_images(input_file)
 
         completions = []
-        for image_batch in batched(load_images(input_file), context.batch_size):
+        for image_batch in batched(load_images(input_file), context.buffer_size):
             messages = [
                 _format_message(
                     image=image,

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -152,42 +152,11 @@ class _OCRBase:
                 for image in image_batch
             ]
             output = context.LLM.chat(messages, **context.chat_kwargs)
-            completions.extend(o.outputs[0] for o in output)
+            for completion in (o.outputs[0] for o in output):
+                page = len(completions) + 1
+                _check_completion(context, completion, page, output_format)
+                completions.append(completion)
             logger.info(f"    Processed {len(completions)}/{total} pages")
-
-        for page, completion in enumerate(completions, start=1):
-            if completion.finish_reason == "length":
-                if page > 1:
-                    msg = (
-                        f"    Output truncated at {context.max_tokens} tokens (page"
-                        f" {page}) — increase --max-tokens and/or --max_model_len"
-                        " for a complete result"
-                    )
-                else:
-                    msg = (
-                        f"    Output truncated at {context.max_tokens} tokens — "
-                        "increase --max-tokens and/or --max_model_len for a "
-                        "complete result"
-                    )
-                logger.warning(msg)
-            elif completion.finish_reason != "stop":
-                if page > 1:
-                    msg = (
-                        "Unexpected finish reason on page "
-                        f"{page}: {completion.finish_reason!r}"
-                    )
-                else:
-                    msg = f"Unexpected finish reason: {completion.finish_reason!r}"
-                raise RuntimeError(msg)
-            if output_format == OutputFormat.JSON:
-                completion.text = strip_markdown_from_json(completion.text)
-            if not completion.text.strip():  # empty model output
-                if page > 1:
-                    msg = f"    Model output empty on page {page}"
-                else:
-                    msg = "    Model output empty"
-                logger.warning(msg)
-            _validate_output_format(completion.text, output_format)
 
         output_text = _format_output(
             outputs=(c.text for c in completions), output_format=output_format
@@ -195,6 +164,45 @@ class _OCRBase:
 
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(output_text)
+
+
+def _check_completion(
+    context: SetupContext, completion, page: int, output_format: OutputFormat
+) -> None:
+    """Validate a single page's completion, raising/warning as soon as it's
+    available rather than after the whole (possibly hundreds-of-pages)
+    document has been generated."""
+    if completion.finish_reason == "length":
+        if page > 1:
+            msg = (
+                f"    Output truncated at {context.max_tokens} tokens (page"
+                f" {page}) — increase --max-tokens and/or --max_model_len"
+                " for a complete result"
+            )
+        else:
+            msg = (
+                f"    Output truncated at {context.max_tokens} tokens — "
+                "increase --max-tokens and/or --max_model_len for a "
+                "complete result"
+            )
+        logger.warning(msg)
+    elif completion.finish_reason != "stop":
+        if page > 1:
+            msg = (
+                f"Unexpected finish reason on page {page}: {completion.finish_reason!r}"
+            )
+        else:
+            msg = f"Unexpected finish reason: {completion.finish_reason!r}"
+        raise RuntimeError(msg)
+    if output_format == OutputFormat.JSON:
+        completion.text = strip_markdown_from_json(completion.text)
+    if not completion.text.strip():  # empty model output
+        if page > 1:
+            msg = f"    Model output empty on page {page}"
+        else:
+            msg = "    Model output empty"
+        logger.warning(msg)
+    _validate_output_format(completion.text, output_format=output_format, page=page)
 
 
 def _format_message(
@@ -236,7 +244,9 @@ def _determine_output_format(path: Path) -> OutputFormat:
     return format
 
 
-def _validate_output_format(output: str, output_format: OutputFormat) -> None:
+def _validate_output_format(
+    output: str, output_format: OutputFormat, page: int
+) -> None:
     """Raise error if model output doesn't match specified output format"""
     if output_format == OutputFormat.TEXT:
         # no validation required
@@ -245,12 +255,21 @@ def _validate_output_format(output: str, output_format: OutputFormat) -> None:
         try:
             json.loads(output)
         except json.JSONDecodeError as e:
-            raise ValueError(
-                "Model did not return a valid json output."
-                " Try refining your prompt or save to a different format."
-                f" See line {e.lineno} column {e.colno} (char {e.pos}):"
-                f" {output!r}"
-            ) from e
+            if page > 1:
+                msg = (
+                    f"Model did not return a valid json output for page {page}."
+                    " Try refining your prompt or save to a different format."
+                    f" See line {e.lineno} column {e.colno} (char {e.pos}):"
+                    f" {output!r}"
+                )
+            else:
+                msg = (
+                    f"Model did not return a valid json output."
+                    " Try refining your prompt or save to a different format."
+                    f" See line {e.lineno} column {e.colno} (char {e.pos}):"
+                    f" {output!r}"
+                )
+            raise ValueError(msg) from e
     else:
         raise ValueError(f" Unsupported output format: {output_format}")
 

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -151,6 +151,7 @@ class _OCRBase:
                 )
                 for image in image_batch
             ]
+            _check_gpu_memory_for_batch(image_batch, context.buffer_size)
             output = context.LLM.chat(messages, **context.chat_kwargs)
             for completion in (o.outputs[0] for o in output):
                 page = len(completions) + 1
@@ -164,6 +165,32 @@ class _OCRBase:
 
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(output_text)
+
+
+def _check_gpu_memory_for_batch(image_batch: list, batch_size: int) -> None:
+    """Raise before sending `image_batch` to the model if it's unlikely to
+    fit in free GPU memory.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        return
+
+    total_free_bytes = 0
+    for i in range(torch.cuda.device_count()):
+        free_bytes, _total_bytes = torch.cuda.mem_get_info(i)
+        total_free_bytes += free_bytes
+
+    total_pixels = sum(img.width * img.height for img in image_batch)
+    needed_bytes = total_pixels * 3 * 64
+
+    if needed_bytes > (total_free_bytes * 0.9):
+        raise RuntimeError(
+            f"Estimated GPU memory for a batch of {len(image_batch)} page(s) "
+            f"(~{needed_bytes / 1e9:.2f} GB) exceeds estimated free GPU memory "
+            f"(~{total_free_bytes / 1e9:.2f} GB). Try lowering --buffer-size "
+            f"(currently {batch_size})."
+        )
 
 
 def _check_completion(

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -16,6 +16,8 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
+    batched,
+    count_images,
     load_images,
     parse_kwargs,
     process_response_schema,
@@ -60,6 +62,14 @@ class _OCRBase:
                 )
             ),
         ] = None
+
+        batch_size: Annotated[
+            int,
+            typer.Option(
+                help="Number of PDF pages sent to the model per chat() call.",
+                min=1,
+            ),
+        ] = 20
 
     @staticmethod
     def setup(context: SetupContext):
@@ -128,21 +138,23 @@ class _OCRBase:
 
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
-        images = load_images(input_file)
-        logger.info(f"    Loaded {len(images)} image(s)")
         output_format = _determine_output_format(output_file)
+        total = count_images(input_file)
 
-        messages = []
-        for image in images:
-            message = _format_message(
-                image=image,
-                prompt=context.prompt,
-                system_message=context.system_message,
-            )
-            messages.append(message)
+        completions = []
+        for image_batch in batched(load_images(input_file), context.batch_size):
+            messages = [
+                _format_message(
+                    image=image,
+                    prompt=context.prompt,
+                    system_message=context.system_message,
+                )
+                for image in image_batch
+            ]
+            output = context.LLM.chat(messages, **context.chat_kwargs)
+            completions.extend(o.outputs[0] for o in output)
+            logger.info(f"    Processed {len(completions)}/{total} pages")
 
-        output = context.LLM.chat(messages, **context.chat_kwargs)
-        completions = [o.outputs[0] for o in output]
         for page, completion in enumerate(completions, start=1):
             if completion.finish_reason == "length":
                 if page > 1:

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -2,6 +2,7 @@
 
 import ast
 import json
+from collections.abc import Iterator
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -105,8 +106,12 @@ _IMG_EXTENSIONS = [
 ]
 
 
-def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"]:
+def load_images(path: Path, max_images: int | None = None) -> Iterator["Image.Image"]:
     """Load images from a file. Supports image files and PDFs.
+
+    PDF pages are rendered lazily, one at a time, so callers that consume
+    the result incrementally (e.g. in batches) don't hold every page of a
+    large PDF in memory at once.
 
     Args:
         path: Path to the file to read.
@@ -114,7 +119,7 @@ def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"
             Defaults to None (returns all).
 
     Returns:
-        A list of PIL images of length <= max_images.
+        An iterator of PIL images of length <= max_images.
 
     Raises:
         ValueError: If max_images is less than 1
@@ -135,23 +140,54 @@ def load_images(path: Path, max_images: int | None = None) -> list["Image.Image"
         raise ValueError(f"max_images must be greater than 0. Received {max_images}")
 
     if path.suffix.lower() == ".pdf":
-        import pymupdf
-
-        limit = max_images if max_images is not None else float("inf")
-        images = []
-        with pymupdf.open(path) as doc:
-            for count, page in enumerate(doc, start=1):
-                if count > limit:
-                    break
-                pix = page.get_pixmap()
-                image = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
-                images.append(image)
-        return images
+        return _iter_pdf_pages(path, max_images)
 
     image = Image.open(path)
     if image.mode != "RGB":
         image = image.convert("RGB")
-    return [image]
+    return iter([image])
+
+
+def count_images(path: Path, max_images: int | None = None) -> int:
+    """Count how many images `load_images` would yield.
+
+    Args:
+        path: Path to the file to read.
+        max_images: The maximum number of images `load_images` would return
+            if input is a PDF. Defaults to None (no cap).
+    """
+    if path.suffix.lower() == ".pdf":
+        import pymupdf
+
+        with pymupdf.open(path) as doc:
+            total = len(doc)
+        return total if max_images is None else min(total, max_images)
+    return 1
+
+
+def _iter_pdf_pages(path: Path, max_images: int | None) -> Iterator["Image.Image"]:
+    import pymupdf
+    from PIL import Image
+
+    limit = max_images if max_images is not None else float("inf")
+    with pymupdf.open(path) as doc:
+        for count, page in enumerate(doc, start=1):
+            if count > limit:
+                break
+            pix = page.get_pixmap()
+            yield Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
+
+
+def batched(iterable: Iterator, n: int) -> Iterator[list]:
+    """Yield successive lists of up to n items from iterable."""
+    batch: list = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) == n:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
 
 
 def parse_kwargs(value: str | dict, *, name: str = "kwargs") -> dict:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,6 +10,8 @@ from tigerflow_ml.utils import (
     EmptyFileError,
     ModelConfigParsingError,
     SchemaType,
+    batched,
+    count_images,
     get_model_config,
     get_model_context_window,
     get_tokenizer,
@@ -228,29 +230,29 @@ def _make_pdf_file(path, num_pages=1):
 class TestLoadImages:
     def test_converts_non_rgb_image_to_rgb(self, tmp_path):
         path = _make_image_file(tmp_path / "test.png", mode="L", color=128)
-        images = load_images(path)
+        images = list(load_images(path))
         assert len(images) == 1
         assert images[0].mode == "RGB"
 
     def test_max_images_ignored_for_single_image_file(self, tmp_path):
         path = _make_image_file(tmp_path / "test.png")
-        images = load_images(path, max_images=5)
+        images = list(load_images(path, max_images=5))
         assert len(images) == 1
 
     def test_loads_all_pdf_pages_by_default(self, tmp_path):
         path = _make_pdf_file(tmp_path / "test.pdf", num_pages=3)
-        images = load_images(path)
+        images = list(load_images(path))
         assert len(images) == 3
         assert all(image.mode == "RGB" for image in images)
 
     def test_max_images_limits_pdf_pages(self, tmp_path):
         path = _make_pdf_file(tmp_path / "test.pdf", num_pages=5)
-        images = load_images(path, max_images=2)
+        images = list(load_images(path, max_images=2))
         assert len(images) == 2
 
     def test_max_images_larger_than_page_count_returns_all(self, tmp_path):
         path = _make_pdf_file(tmp_path / "test.pdf", num_pages=2)
-        images = load_images(path, max_images=10)
+        images = list(load_images(path, max_images=10))
         assert len(images) == 2
 
     def test_max_images_zero_raises(self, tmp_path):
@@ -263,7 +265,7 @@ class TestLoadImages:
 
     def test_loads_heic_image(self, tmp_path):
         path = _make_heic_file(tmp_path / "test.heic")
-        images = load_images(path)
+        images = list(load_images(path))
         assert len(images) == 1
         assert images[0].mode == "RGB"
 
@@ -276,10 +278,41 @@ class TestLoadImages:
                 continue
             else:
                 path = _make_image_file(tmp_path / file)
-            images = load_images(path)
+            images = list(load_images(path))
             assert len(images) == 1
         with pytest.raises(ValueError, match="not a valid file type"):
             load_images(tmp_path / "test.txt")
+
+
+class TestCountImages:
+    def test_counts_pdf_pages_without_max_images(self, tmp_path):
+        path = _make_pdf_file(tmp_path / "test.pdf", num_pages=5)
+        assert count_images(path) == 5
+
+    def test_counts_pdf_pages_capped_by_max_images(self, tmp_path):
+        path = _make_pdf_file(tmp_path / "test.pdf", num_pages=5)
+        assert count_images(path, max_images=2) == 2
+
+    def test_max_images_larger_than_page_count_returns_page_count(self, tmp_path):
+        path = _make_pdf_file(tmp_path / "test.pdf", num_pages=2)
+        assert count_images(path, max_images=10) == 2
+
+    def test_single_image_file_counts_as_one(self, tmp_path):
+        path = _make_image_file(tmp_path / "test.png")
+        assert count_images(path) == 1
+
+
+class TestBatched:
+    def test_splits_into_full_batches(self):
+        result = list(batched(iter(range(6)), 2))
+        assert result == [[0, 1], [2, 3], [4, 5]]
+
+    def test_last_batch_may_be_partial(self):
+        result = list(batched(iter(range(5)), 2))
+        assert result == [[0, 1], [2, 3], [4]]
+
+    def test_empty_iterable_yields_nothing(self):
+        assert list(batched(iter([]), 3)) == []
 
 
 class TestStripMarkdownFromJson:

--- a/tests/unit/text/ocr/test_ocr.py
+++ b/tests/unit/text/ocr/test_ocr.py
@@ -13,35 +13,43 @@ from tigerflow_ml.text.ocr._base import (
 
 class TestValidateOutputFormat:
     def test_txt_plain_string_passes(self):
-        _validate_output_format("hello world", OutputFormat.TEXT)
+        _validate_output_format("hello world", OutputFormat.TEXT, page=1)
 
     def test_txt_empty_string_passes(self):
-        _validate_output_format("", OutputFormat.TEXT)
+        _validate_output_format("", OutputFormat.TEXT, page=1)
 
     def test_txt_with_headers_passes(self):
-        _validate_output_format("# Title\n\nSome text\n\n## Section", OutputFormat.TEXT)
+        _validate_output_format(
+            "# Title\n\nSome text\n\n## Section", OutputFormat.TEXT, page=1
+        )
 
     def test_valid_json_object_passes(self):
-        _validate_output_format('{"key": "value"}', OutputFormat.JSON)
+        _validate_output_format('{"key": "value"}', OutputFormat.JSON, page=1)
 
     def test_valid_json_array_passes(self):
-        _validate_output_format('[{"page": 1, "text": "hello"}]', OutputFormat.JSON)
+        _validate_output_format(
+            '[{"page": 1, "text": "hello"}]', OutputFormat.JSON, page=1
+        )
 
     def test_invalid_json_raises(self):
         with pytest.raises(ValueError):
-            _validate_output_format("not json at all", OutputFormat.JSON)
+            _validate_output_format("not json at all", OutputFormat.JSON, page=1)
 
     def test_truncated_json_raises(self):
         with pytest.raises(ValueError):
-            _validate_output_format('{"key": "val', OutputFormat.JSON)
+            _validate_output_format('{"key": "val', OutputFormat.JSON, page=1)
 
     def test_empty_string_raises(self):
         with pytest.raises(ValueError):
-            _validate_output_format("", OutputFormat.JSON)
+            _validate_output_format("", OutputFormat.JSON, page=1)
 
     def test_unknown_format_raises(self):
         with pytest.raises(ValueError):
-            _validate_output_format("some output", "unknown_format")  # type: ignore[arg-type]
+            _validate_output_format("some output", "unknown_format", page=1)  # type: ignore[arg-type]
+
+    def test_error_includes_page_num_when_greater_than_1(self):
+        with pytest.raises(ValueError, match="for page 3"):
+            _validate_output_format('{"key": "val', OutputFormat.JSON, page=3)
 
 
 class TestFormatOutput:

--- a/tests/unit/text/ocr/test_params.py
+++ b/tests/unit/text/ocr/test_params.py
@@ -5,3 +5,4 @@ def test_ocr_defaults():
     p = _OCRBase.Params()
     assert p.max_tokens == 4096
     assert p.json_schema is None
+    assert p.buffer_size == 100


### PR DESCRIPTION
Now, PDF pages are rendered lazily, one at a time, so callers that consume the result incrementally don't hold every page of a large PDF in memory at once.

Uses functionality from the detect task and updates OCR calls.

Also adds helper count_images(), primarily for cleaner logging.

Closes #186 