### PR TITLE
refactor: improve model load failure error message based on env

### DIFF
--- a/src/tigerflow_ml/audio/transcribe/transcriber.py
+++ b/src/tigerflow_ml/audio/transcribe/transcriber.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 from tigerflow.logconfig import logger
 
+from tigerflow_ml.utils import raise_model_load_error
+
 if TYPE_CHECKING:
     import numpy as np
     from transformers import (
@@ -315,12 +317,7 @@ def load_whisper(
             device_map=device,
         )
     except OSError as e:
-        if local_files_only:
-            raise RuntimeError(
-                f"'{model}' not found in cache ({cache_dir}). "
-                "Run with --allow-fetch or download manually."
-            ) from e
-        raise
+        raise_model_load_error(model, cache_dir, allow_fetch, e)
 
     # from_pretrained() returns the model already in inference mode and all
     # generation runs under torch.no_grad(), so switching modes is redundant.

--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -104,7 +104,7 @@ class _DetectBase:
             MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES,
         )
 
-        from tigerflow_ml.utils import get_model_config
+        from tigerflow_ml.utils import get_model_config, raise_model_load_error
 
         set_seed(context.seed)
 
@@ -152,12 +152,9 @@ class _DetectBase:
                 model_kwargs={"cache_dir": context.cache_dir or None},
             )
         except OSError as e:
-            if not context.allow_fetch:
-                raise RuntimeError(
-                    f"'{context.model}' not found in cache ({context.cache_dir}). "
-                    "Run with --allow_fetch or download manually."
-                ) from e
-            raise
+            raise_model_load_error(
+                context.model, context.cache_dir, context.allow_fetch, e
+            )
 
         if context.compile:
             try:

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -15,6 +15,7 @@ from tigerflow_ml.utils import (
     load_images,
     parse_kwargs,
     process_response_schema,
+    raise_model_load_error,
     read_text_file_strict,
 )
 
@@ -89,14 +90,9 @@ class _ChatBase:
                 revision=context.revision,
             )
         except OSError as e:
-            if not context.allow_fetch:
-                logger.error(f"Model '{context.model}' not found in cache.")
-                logger.error(
-                    "  Run with --allow-fetch to download, or pre-download with:"
-                )
-                logger.error(f"    hf download {context.model}")
-                raise typer.Exit(1)
-            raise RuntimeError(f"Failed to download '{context.model}': {e}") from e
+            raise_model_load_error(
+                context.model, context.cache_dir, context.allow_fetch, e
+            )
 
         from vllm import LLM, SamplingParams  # type: ignore
 

--- a/src/tigerflow_ml/text/ocr/_base.py
+++ b/src/tigerflow_ml/text/ocr/_base.py
@@ -19,6 +19,7 @@ from tigerflow_ml.utils import (
     load_images,
     parse_kwargs,
     process_response_schema,
+    raise_model_load_error,
     strip_markdown_from_json,
 )
 
@@ -78,12 +79,9 @@ class _OCRBase:
                 revision=context.revision,
             )
         except OSError as e:
-            if not context.allow_fetch:
-                raise RuntimeError(
-                    f"'{context.model}' not found in cache ({context.cache_dir}). "
-                    "Run with --allow_fetch or download manually."
-                ) from e
-            raise
+            raise_model_load_error(
+                context.model, context.cache_dir, context.allow_fetch, e
+            )
 
         tp = torch.cuda.device_count() or 1
 

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -2,6 +2,7 @@
 
 import ast
 import json
+import os
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -232,6 +233,27 @@ def process_response_schema(
         return StructuredOutputsParams(grammar=schema_value)
 
 
+def raise_model_load_error(
+    model: str, cache_dir: str | None, allow_fetch: bool, cause: OSError
+):
+    """
+    Convert a failed model/config load's OSError into an actionable error.
+    """
+    if "SLURM_JOB_ID" in os.environ:
+        raise RuntimeError(
+            f"'{model}' not found in cache ({cache_dir}). "
+            "Compute nodes have no internet access -- pre-download "
+            "the model on a login node (or check "
+            "--cache-dir), then rerun."
+        ) from cause
+    if not allow_fetch:
+        raise RuntimeError(
+            f"'{model}' not found in cache ({cache_dir}). "
+            "Run with --allow-fetch or download manually."
+        ) from cause
+    raise cause  # off-node + allow_fetch: bad repo id or transient network
+
+
 def get_model_config(
     model: str,
     allow_fetch: bool = False,
@@ -251,10 +273,11 @@ def get_model_config(
         The model's PretrainedConfig (architecture, vocab size, etc.).
 
     Raises:
-        FileNotFoundError: If the config cannot be found in the cache dir and
-            --allow-fetch is False
-        ModelConfigParsingError: If the config cannot be loaded or parsed, wrapping
-            any underlying error.
+        RuntimeError: If the config cannot be found in the cache dir and
+            --allow-fetch is False, or the job is running on a Slurm compute
+            node (which has no internet access).
+        ModelConfigParsingError: If the config cannot be loaded or parsed for
+            reasons other than the cases above, wrapping any underlying error.
     """
     from transformers import AutoConfig
 
@@ -266,14 +289,7 @@ def get_model_config(
             revision=revision,
         )
     except OSError as e:
-        if not allow_fetch:
-            raise FileNotFoundError(
-                f"Config for '{model}' not found in cache ({cache_dir}). "
-                "Run with --allow_fetch to download, or manually with: "
-                f"hf download {model}"
-            ) from e
-
-        raise ModelConfigParsingError(f"Failed to load model config: {e}") from e
+        raise_model_load_error(model, cache_dir, allow_fetch, e)
     except Exception as e:
         raise ModelConfigParsingError(f"Failed to load model config: {e}") from e
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -135,17 +135,26 @@ class TestGetModelConfig:
             revision="v1",
         )
 
-    def test_oserror_no_fetch_raises_file_not_found(self):
+    def test_oserror_no_fetch_raises_runtime_error(self):
         with patch("transformers.AutoConfig.from_pretrained", side_effect=OSError):
-            with pytest.raises(FileNotFoundError, match="some/model"):
+            with pytest.raises(RuntimeError, match="some/model"):
                 get_model_config("some/model", allow_fetch=False)
 
-    def test_oserror_allow_fetch_raises_config_parsing_error(self):
+    def test_oserror_allow_fetch_reraises_oserror(self):
         with patch(
             "transformers.AutoConfig.from_pretrained",
             side_effect=OSError("network error"),
         ):
-            with pytest.raises(ModelConfigParsingError):
+            with pytest.raises(OSError, match="network error"):
+                get_model_config("some/model", allow_fetch=True)
+
+    def test_oserror_on_slurm_node_raises_no_internet_message(self, monkeypatch):
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=OSError("network error"),
+        ):
+            with pytest.raises(RuntimeError, match="Compute nodes have no internet"):
                 get_model_config("some/model", allow_fetch=True)
 
     def test_unexpected_exception_raises_config_parsing_error(self):

--- a/tests/unit/text/chat/test_chat.py
+++ b/tests/unit/text/chat/test_chat.py
@@ -95,9 +95,9 @@ class TestSetup:
         with pytest.raises(ValueError, match="max_tokens"):
             _ChatBase.setup(context)
 
-    def test_model_not_found_without_allow_fetch_exits(self):
+    def test_model_not_found_without_allow_fetch_raises(self):
         context = _make_context(allow_fetch=False)
-        with pytest.raises(RuntimeError, match="1"):
+        with pytest.raises(RuntimeError, match="test-model.*not found in cache"):
             _ChatBase.setup(context)
 
 


### PR DESCRIPTION
Updates error messages to provide more specific advice based on runtime environment. 
- Adds `raise_model_load_error()` to the shared utils; this helper formats the error message. If running on a compute node (`if "SLURM_JOB_ID" in os.environ`), advice is to pre-download the model and confirm correct `--cache-dir` is being used. If not running on a compute node, user is advised to run with `--allow-fetch` if not enabled, otherwise original error is raised. 
- All tasks which originally handled this error now use the helper. This helper is called for failures in `.from_pretrained()`, `pipeline()`, and `snapshot_download()` calls.
- Updates tests to reflect new behavior.


Closes #104 