### PR TITLE
fix(chat): update to use iterator version of load_images

### DIFF
--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -181,7 +181,7 @@ class _ChatBase:
     def _process_img_file(context: SetupContext, input_file: Path) -> str:
         import PIL.Image
 
-        image = load_images(path=input_file)[0]
+        image = next(load_images(path=input_file, max_images=1))
 
         if context.max_image_pixels is not None:
             original_size = image.size


### PR DESCRIPTION
In previous PR #187,  the helper `load_images` was updated to return an iterator. This PR updates the `chat` task to be compatible with this update. 

Since the `chat` task only supports images (not pdfs), there should always only be one image in the iterator. 