### PR TITLE
refactor(transcribe): update to use shared load_audio helper

### DIFF
--- a/src/tigerflow_ml/audio/transcribe/transcriber.py
+++ b/src/tigerflow_ml/audio/transcribe/transcriber.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 from tigerflow.logconfig import logger
 
-from tigerflow_ml.utils import raise_model_load_error
+from tigerflow_ml.utils import load_audio, raise_model_load_error
 
 if TYPE_CHECKING:
     import numpy as np
@@ -430,30 +430,6 @@ def _flatten_sequences(predicted_ids: Any) -> list[list[int]]:
     return sequences
 
 
-def load_audio(input_file: Path) -> np.ndarray:
-    """Load an audio file as a 16kHz mono float32 array.
-
-    Decodes with ``soundfile``, averages channels to mono, and resamples to
-    16kHz with ``soxr`` if needed.
-
-    Args:
-        input_file: Path to the audio file.
-
-    Returns:
-        A 1-D float32 array of samples at 16kHz.
-    """
-    import numpy as np
-    import soundfile as sf
-    import soxr
-
-    array, sr = sf.read(str(input_file), dtype="float32", always_2d=False)
-    if array.ndim > 1:
-        array = array.mean(axis=1)
-    if sr != SAMPLING_RATE:
-        array = soxr.resample(array, sr, SAMPLING_RATE)
-    return np.ascontiguousarray(array, dtype=np.float32)
-
-
 def transcribe_audio(
     input_file: Path,
     whisper: WhisperForConditionalGeneration,
@@ -482,7 +458,7 @@ def transcribe_audio(
     Returns:
         A ``TranscriptionResult`` holding the per-window transcriptions.
     """
-    array = load_audio(input_file)
+    array = load_audio(input_file, sampling_rate=SAMPLING_RATE)
     duration = len(array) / SAMPLING_RATE
     logger.info(f"Audio duration: {duration:.1f}s")
 
@@ -538,7 +514,7 @@ def transcribe_audio_native(
     """
     import torch
 
-    array = load_audio(input_file)
+    array = load_audio(input_file, sampling_rate=SAMPLING_RATE)
     duration = len(array) / SAMPLING_RATE
     logger.info(f"Audio duration: {duration:.1f}s (native long-form)")
 

--- a/tests/unit/audio/transcribe/test_transcriber.py
+++ b/tests/unit/audio/transcribe/test_transcriber.py
@@ -11,10 +11,10 @@ from tigerflow_ml.audio.transcribe.transcriber import (
     BatchIterator,
     Transcription,
     _flatten_sequences,
-    load_audio,
     load_whisper,
     merge_overlapping,
 )
+from tigerflow_ml.utils import load_audio
 
 _FIXTURE = (
     Path(__file__).parents[3] / "integration" / "fixtures" / "transcribe" / "sample.wav"
@@ -41,12 +41,12 @@ class TestLoadAudioErrors:
         bad = tmp_path / "not-audio.wav"
         bad.write_bytes(b"this is not a wav file")
         with pytest.raises(Exception):
-            load_audio(bad)
+            load_audio(bad, sampling_rate=SAMPLING_RATE)
 
 
 class TestLoadAudio:
     def test_returns_mono_float32_at_16khz(self):
-        array = load_audio(_FIXTURE)
+        array = load_audio(_FIXTURE, sampling_rate=SAMPLING_RATE)
         assert array.dtype == np.float32
         assert array.ndim == 1
         # ~2.5s fixture at 16kHz.


### PR DESCRIPTION
Refactors the `transcribe` task to use the shared `load_audio` helper from `utils.py`

Closes #173 