### PR TITLE
feat(embed): add --use-encode-query

### DIFF
--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -16,6 +16,8 @@ Embed text using HuggingFace sentence-transformers models.
 | `--normalize`       | `--no-normalize`   | Whether to normalize returned vectors to have length 1                                                             |
 | `--truncate-dim`    |                    | The dimension to truncate sentence embeddings to                                                                   |
 | `--use-encode-document` | `--no-use-encode-document` | Use SentenceTransformer's `encode_document()` instead of `encode()`. See [SentenceTransformer's documentation](https://sbert.net/docs/package_reference/sentence_transformer/model.html#sentence_transformers.sentence_transformer.model.SentenceTransformer.encode_document) for more information. |
+| `--use-encode-query` | `--no-use-encode-query` | Use SentenceTransformer's `encode_query()` instead of `encode()`. See [SentenceTransformer's documentation](https://sbert.net/docs/package_reference/sentence_transformer/model.html#sentence_transformers.sentence_transformer.model.SentenceTransformer.encode_query) for more information. |
+
 
 ## Supported Input Formats
 

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import numpy as np
 import typer
@@ -23,6 +23,14 @@ class _EmbedBase:
                 "method instead of the regular encode()."
             ),
         ] = False
+
+        use_encode_query: Annotated[
+            bool,
+            typer.Option(
+                help="Whether to use SentenceTransformer's encode_query() "
+                "method instead of the regular encode()."
+            ),
+        ]
 
         normalize: Annotated[
             bool,
@@ -48,6 +56,11 @@ class _EmbedBase:
     def setup(context: SetupContext):
         import torch
         from sentence_transformers import SentenceTransformer
+
+        if context.use_encode_document and context.use_encode_query:
+            raise ValueError(
+                "--use-encode-document and --use-encode-query are mutually exclusive"
+            )
 
         device = context.device
         if context.device == "auto":
@@ -96,7 +109,6 @@ class _EmbedBase:
             embeddings = _EmbedBase._embed_text(
                 context=context,
                 input_file=input_file,
-                encode_kwargs=context.encode_kwargs,
             )
         else:
             raise ValueError(
@@ -106,14 +118,16 @@ class _EmbedBase:
         np.save(output_file, embeddings)
 
     @staticmethod
-    def _embed_text(
-        context: SetupContext, input_file: Path, encode_kwargs: dict[str, Any]
-    ):
+    def _embed_text(context: SetupContext, input_file: Path):
         content = read_text_file_strict(input_file)
 
         if context.use_encode_document:
-            embeddings = context.embedder.encode_document(content, **encode_kwargs)
+            embeddings = context.embedder.encode_document(
+                content, **context.encode_kwargs
+            )
+        elif context.use_encode_query:
+            embeddings = context.embedder.encode_query(content, **context.encode_kwargs)
         else:
-            embeddings = context.embedder.encode(content, **encode_kwargs)
+            embeddings = context.embedder.encode(content, **context.encode_kwargs)
         logger.info(f"   Embedded 1 document with shape {embeddings.shape}")
         return embeddings

--- a/tests/unit/text/embed/test_embed.py
+++ b/tests/unit/text/embed/test_embed.py
@@ -22,12 +22,18 @@ def _make_context(**kwargs):
         normalize=False,
         truncate_dim=None,
         use_encode_document=False,
+        use_encode_query=False,
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
 
 
 class TestSetup:
+    def test_use_query_and_use_document_mutually_exclusive(self):
+        context = _make_context(use_encode_document=True, use_encode_query=True)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _EmbedBase.setup(context)
+
     def test_model_not_found_without_allow_fetch_raises(self):
         context = _make_context(allow_fetch=False)
         with pytest.raises(RuntimeError, match="not found in cache"):
@@ -39,7 +45,8 @@ class TestRun:
         context = _make_context(**context_kwargs)
         context.embedder = MagicMock()
         context.embedder.encode.return_value = np.zeros(4)
-        context.embedder.encode_document.return_value = np.zeros(4)
+        context.embedder.encode_document.return_value = np.zeros(5)
+        context.embedder.encode_query.return_value = np.zeros(6)
 
         # Mirrors the resolution _EmbedBase.setup() performs on context.encode_kwargs.
         user_encode_kwargs = parse_kwargs(context.encode_kwargs)
@@ -108,6 +115,8 @@ class TestRun:
 
         context.embedder.encode.assert_called_once()
         context.embedder.encode_document.assert_not_called()
+        context.embedder.encode_query.assert_not_called()
+
         args, _ = context.embedder.encode.call_args
         assert args[0] == "hello world"
         assert output_file.exists()
@@ -119,6 +128,19 @@ class TestRun:
 
         context.embedder.encode_document.assert_called_once()
         context.embedder.encode.assert_not_called()
+        context.embedder.encode_query.assert_not_called()
+
         args, _ = context.embedder.encode_document.call_args
+        assert args[0] == "hello world"
+        assert output_file.exists()
+
+    def test_uses_encode_query_when_set(self, tmp_path):
+        context, output_file = self._run(tmp_path, "hello world", use_encode_query=True)
+
+        context.embedder.encode_query.assert_called_once()
+        context.embedder.encode.assert_not_called()
+        context.embedder.encode_document.assert_not_called()
+
+        args, _ = context.embedder.encode_query.call_args
         assert args[0] == "hello world"
         assert output_file.exists()


### PR DESCRIPTION
Adds the `--use-encode-query` param to the `embed` task to go with the preexisting`--use-document-encode` param