### PR TITLE
refactor: moves duplicate extension lists to shared utils

### DIFF
--- a/src/tigerflow_ml/image/detect/_base.py
+++ b/src/tigerflow_ml/image/detect/_base.py
@@ -23,9 +23,7 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
-from tigerflow_ml.utils import batched
-
-_VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
+from tigerflow_ml.utils import VIDEO_EXTENSIONS, batched
 
 
 class Dtype(str, Enum):
@@ -179,7 +177,7 @@ class _DetectBase:
     def run(context: SetupContext, input_file: Path, output_file: Path):
         logger.info(f"Processing: {input_file}")
 
-        is_video = input_file.suffix.lower() in _VIDEO_EXTENSIONS
+        is_video = input_file.suffix.lower() in VIDEO_EXTENSIONS
         if is_video:
             output = _run_video(context, input_file)
         else:

--- a/src/tigerflow_ml/text/chat/_base.py
+++ b/src/tigerflow_ml/text/chat/_base.py
@@ -12,7 +12,10 @@ from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import VLLMParams
 from tigerflow_ml.utils import (
+    AUDIO_EXTENSIONS,
     IMG_EXTENSIONS,
+    TEXT_EXTENSIONS,
+    VIDEO_EXTENSIONS,
     load_audio,
     load_images,
     load_video,
@@ -21,10 +24,6 @@ from tigerflow_ml.utils import (
     raise_model_load_error,
     read_text_file_strict,
 )
-
-_TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
-_AUDIO_EXTENSIONS = [".wav", ".flac", ".ogg", ".aiff", ".aif", ".mp3"]
-_VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"]
 
 
 class _ChatBase:
@@ -166,7 +165,7 @@ class _ChatBase:
     @staticmethod
     def run(context: SetupContext, input_file: Path, output_file: Path):
 
-        if input_file.suffix.lower() in _TEXT_EXTENSIONS:
+        if input_file.suffix.lower() in TEXT_EXTENSIONS:
             result = _ChatBase._process_text_file(context, input_file)
         elif input_file.suffix.lower() in IMG_EXTENSIONS:
             if input_file.suffix.lower() == ".pdf":
@@ -175,9 +174,9 @@ class _ChatBase:
                     "raise an issue on Github"
                 )
             result = _ChatBase._process_img_file(context, input_file)
-        elif input_file.suffix.lower() in _AUDIO_EXTENSIONS:
+        elif input_file.suffix.lower() in AUDIO_EXTENSIONS:
             result = _ChatBase._process_audio_file(context, input_file)
-        elif input_file.suffix.lower() in _VIDEO_EXTENSIONS:
+        elif input_file.suffix.lower() in VIDEO_EXTENSIONS:
             result = _ChatBase._process_video_file(context, input_file)
         else:
             raise ValueError(

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -7,9 +7,7 @@ from tigerflow.logconfig import logger
 from tigerflow.utils import SetupContext
 
 from tigerflow_ml.params import HFParams
-from tigerflow_ml.utils import parse_kwargs, read_text_file_strict
-
-_TEXT_EXTENSIONS = [".txt", ".text", ".md", ".log", ".rtf"]
+from tigerflow_ml.utils import TEXT_EXTENSIONS, parse_kwargs, read_text_file_strict
 
 
 class _EmbedBase:
@@ -105,7 +103,7 @@ class _EmbedBase:
                 "save to a .npy file."
             )
 
-        if input_file.suffix.lower() in _TEXT_EXTENSIONS:
+        if input_file.suffix.lower() in TEXT_EXTENSIONS:
             embeddings = _EmbedBase._embed_text(
                 context=context,
                 input_file=input_file,

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -16,6 +16,21 @@ if TYPE_CHECKING:
     from transformers import PretrainedConfig, PreTrainedTokenizerBase
     from vllm.sampling_params import StructuredOutputsParams  # type: ignore
 
+TEXT_EXTENSIONS = {".txt", ".text", ".md", ".log", ".rtf"}
+IMG_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".tiff",
+    ".tif",
+    ".bmp",
+    ".pdf",
+    ".heic",
+    ".heif",
+}
+AUDIO_EXTENSIONS = {".wav", ".flac", ".ogg", ".aiff", ".aif", ".mp3"}
+VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
+
 
 class EmptyFileError(Exception):
     """Raised when an input file is empty"""
@@ -93,19 +108,6 @@ def read_text_file_strict(path: Path) -> str:
     if not content.strip():
         raise EmptyFileError(f"File is empty: {path}")
     return content
-
-
-IMG_EXTENSIONS = [
-    ".jpg",
-    ".jpeg",
-    ".png",
-    ".tiff",
-    ".tif",
-    ".bmp",
-    ".pdf",
-    ".heic",
-    ".heif",
-]
 
 
 def load_images(path: Path, max_images: int | None = None) -> Iterator["Image.Image"]:


### PR DESCRIPTION
Simple refactor to move duplicate supported file extension lists to the shared utils file. All stored as sets now, not lists. 

Closes #175