### PR TITLE
ci: reduce vLLM GPU memory utilization in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,6 +41,17 @@ jobs:
   integration:
     runs-on: [self-hosted, 2xH100]
     steps:
+      - name: Preflight
+        run: |
+          echo "hostname -f:  $(hostname -f)"
+          echo "PATH=$PATH"
+          command -v nvidia-smi || echo "nvidia-smi NOT on PATH"
+          ls -l /usr/bin/nvidia-smi 2>/dev/null || echo "not at /usr/bin/nvidia-smi"
+          # Absolute path: ldconfig lives in /sbin, which a minimal service
+          # PATH may omit — the very condition this step is diagnosing.
+          /sbin/ldconfig -p | grep -c libcuda.so || true
+          ls /dev/nvidia* 2>/dev/null || echo "no device nodes"
+
       - uses: actions/checkout@v7
         with:
           # Belt and suspenders: never check out a non-main ref on the

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,16 +41,17 @@ jobs:
   integration:
     runs-on: [self-hosted, 2xH100]
     steps:
-      - name: Preflight
+      # della-rse is shared and persistent — no Slurm allocation gives us
+      # exclusive GPUs. Record who else is on the cards, so a failure further
+      # down can be attributed to contention rather than to the change under
+      # test. See default_config.json for the matching memory budget.
+      - name: GPU status
         run: |
-          echo "hostname -f:  $(hostname -f)"
-          echo "PATH=$PATH"
-          command -v nvidia-smi || echo "nvidia-smi NOT on PATH"
-          ls -l /usr/bin/nvidia-smi 2>/dev/null || echo "not at /usr/bin/nvidia-smi"
-          # Absolute path: ldconfig lives in /sbin, which a minimal service
-          # PATH may omit — the very condition this step is diagnosing.
-          /sbin/ldconfig -p | grep -c libcuda.so || true
-          ls /dev/nvidia* 2>/dev/null || echo "no device nodes"
+          echo "node: $(hostname -f)"
+          nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu \
+            --format=csv
+          echo "--- processes holding GPU memory ---"
+          nvidia-smi --query-compute-apps=pid,used_memory,process_name --format=csv
 
       - uses: actions/checkout@v7
         with:

--- a/tests/integration/default_config.json
+++ b/tests/integration/default_config.json
@@ -3,12 +3,18 @@
     "ocr": {
       "model": "Qwen/Qwen2.5-VL-3B-Instruct",
       "revision": "66285546d2b821cf421d4f5eb2576359d3770cd3",
-      "prompt": "Extract all text from this image in plain text format."
+      "prompt": "Extract all text from this image in plain text format.",
+      "llm_kwargs": {
+        "gpu_memory_utilization": 0.3
+      }
     },
     "translate": {
       "model": "google/gemma-3-1b-it",
       "revision": "dcc83ea841ab6100d6b47a070329e1ba4cf78752",
-      "device": "auto"
+      "device": "auto",
+      "llm_kwargs": {
+        "gpu_memory_utilization": 0.3
+      }
     },
     "transcribe": {
       "model": "openai/whisper-large-v3",
@@ -27,7 +33,8 @@
       "llm_kwargs": {
         "enforce_eager": true,
         "enable_prefix_caching": false,
-        "max_num_seqs": 1
+        "max_num_seqs": 1,
+        "gpu_memory_utilization": 0.3
       }
     },
     "embed": {


### PR DESCRIPTION
## Problem

Integration tests intermittently fail with every vLLM-backed task erroring at fixture setup (`test_chat.py EE`, and the same for ocr/translate), surfacing as:

```
RuntimeError: Engine core initialization failed. See root cause above.
```

The root cause is only printed in pytest's end-of-run `ERRORS` section, so it is invisible in any run that was cancelled partway. From run 28024021631:

```
ValueError: Free memory on device cuda:0 (85.25/93.09 GiB) on startup is less than desired GPU memory utilization (0.92, 85.64 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.
```

vLLM sizes its KV cache from memory that is **free at engine init**, so `gpu_memory_utilization` acts as a floor on how empty a card must be. At the default, the suite needs ~85 of 93 GiB free per card. `della-rse` is a shared, persistent node with no Slurm allocation, so another user holding 7.8 GiB was enough to fail the run — by 0.39 GiB.

## Changes

- `default_config.json`: set `llm_kwargs.gpu_memory_utilization: 0.3` for `ocr`, `translate`, and `chat`. Drops the requirement to ~28 GiB per card, tolerating ~65 GiB of other users' work. Config-only — `parse_kwargs` accepts a dict and the tasks apply user kwargs last, so no `src/` changes. The tgemma test inherits it via the shared `translate` config block.
- `integration.yml`: add a **GPU status** step recording per-GPU memory and the processes holding it, so a future failure can be attributed to contention rather than to the change under test.

The test models are small; a 28 GiB KV cache is ample at these input sizes. `transcribe`, `detect`, and `embed` are untouched — they do not use vLLM.

## Verification

Green on `della-rse` (run 31518694307): 26 passed in 5:59, down from 8:25, from vLLM no longer reserving a KV cache it has no use for.

**Note** this run executed on an idle node, so it demonstrates the change is not harmful rather than that it fixes contention. Confirming the fix means holding ~20 GiB on a card and re-running: that fails engine init at 0.92 and should pass at 0.3.

## Follow-ups (not in this PR)

- Fail-fast gate comparing free memory against the configured budget, turning an opaque `EE` at 7% into an immediate, legible error.
- Pin `CUDA_VISIBLE_DEVICES` to the emptiest card. `tp = torch.cuda.device_count()` means the tasks currently shard across both GPUs and need headroom on each; pinning makes `tp=1` and halves the footprint on a shared node, but changes sharding and may perturb snapshot outputs.

Ref #226 