### PR TITLE
refactor: add HF_HOME and HF_HUB_OFFLINE hints to raise_model_load_error

### DIFF
--- a/docs/mkdocs/tasks/embed.md
+++ b/docs/mkdocs/tasks/embed.md
@@ -114,5 +114,6 @@ tasks:
     params:
       model: BAAI/bge-base-en-v1.5
       encode-kwargs: {"prompt":"query: "}
-      cache_dir: ~/path/to/model/hub
+      cache-dir: ~/path/to/model/hub
 ```
+For some models, like `BAAI/bge-base-en-v1.5`, you may need to set `HF_HUB_OFFLINE=1`. Compute nodes will never have internet access, so it is safe to set this for any `slurm` task. If you encounter an error that says your model cannot be found in your specified `--cache-dir` (even though the model is there), you may also need to set `HF_HOME`. (This can be done in the same way/place as `HF_HUB_OFFLINE` in the example above; while `--cache-dir` needs to point at the `hub/` directory, `HF_HOME` should point to the parent directory of `hub/` )

--- a/src/tigerflow_ml/text/embed/_base.py
+++ b/src/tigerflow_ml/text/embed/_base.py
@@ -15,6 +15,7 @@ from tigerflow_ml.utils import (
     count_images,
     load_images,
     parse_kwargs,
+    raise_model_load_error,
     read_text_file_strict,
 )
 
@@ -94,12 +95,9 @@ class _EmbedBase:
                 trust_remote_code=True,
             )
         except OSError as e:
-            if not context.allow_fetch:
-                raise RuntimeError(
-                    f"'{context.model}' not found in cache ({context.cache_dir}). "
-                    "Run with --allow_fetch or download manually."
-                ) from e
-            raise
+            raise_model_load_error(
+                context.model, context.cache_dir, context.allow_fetch, e
+            )
         logger.info(
             f"   Embedding dimension: {context.embedder.get_embedding_dimension()}"
         )

--- a/src/tigerflow_ml/utils.py
+++ b/src/tigerflow_ml/utils.py
@@ -373,17 +373,33 @@ def raise_model_load_error(
     """
     Convert a failed model/config load's OSError into an actionable error.
     """
+    hf_home = os.environ.get("HF_HOME")
+    if os.environ.get("HF_HUB_OFFLINE") not in ("1", "true", "True"):
+        env_hint = (
+            "If the model is in your specified --cache-dir, try setting "
+            "`HF_HUB_OFFLINE=1` and making sure HF_HOME (currently "
+            + (f"{hf_home!r}" if hf_home else "unset")
+            + ") is correctly set."
+        )
+    else:
+        env_hint = (
+            "If the model is in your specified --cache-dir, try making "
+            "sure HF_HOME (currently "
+            + (f"{hf_home!r}" if hf_home else "unset")
+            + ") is correctly set."
+        )
+
     if "SLURM_JOB_ID" in os.environ:
         raise RuntimeError(
             f"'{model}' not found in cache ({cache_dir}). "
             "Compute nodes have no internet access -- pre-download "
             "the model on a login node (or check "
-            "--cache-dir), then rerun."
+            f"--cache-dir), then rerun. {env_hint}"
         ) from cause
     if not allow_fetch:
         raise RuntimeError(
             f"'{model}' not found in cache ({cache_dir}). "
-            "Run with --allow-fetch or download manually."
+            f"Run with --allow-fetch or download manually. {env_hint}"
         ) from cause
     raise cause  # off-node + allow_fetch: bad repo id or transient network
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,6 +21,7 @@ from tigerflow_ml.utils import (
     load_images,
     load_video,
     process_response_schema,
+    raise_model_load_error,
     read_text_file_strict,
     read_text_file_with_fallback,
     strip_markdown_from_json,
@@ -172,6 +173,43 @@ class TestGetModelConfig:
         ):
             with pytest.raises(ModelConfigParsingError, match="bad config"):
                 get_model_config("some/model")
+
+
+class TestRaiseModelLoadError:
+    def test_hf_hub_offline_unset_suggests_setting_it(self, monkeypatch):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+        with pytest.raises(RuntimeError, match="try setting `HF_HUB_OFFLINE=1`"):
+            raise_model_load_error("some/model", "/cache", False, OSError("err"))
+
+    def test_hf_hub_offline_set_does_not_repeat_suggestion(self, monkeypatch):
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+        with pytest.raises(RuntimeError) as exc_info:
+            raise_model_load_error("some/model", "/cache", False, OSError("err"))
+        message = str(exc_info.value)
+        assert "try setting `HF_HUB_OFFLINE=1`" not in message
+        assert "making sure HF_HOME" in message
+
+    def test_hf_home_value_shown_when_set(self, monkeypatch):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+        monkeypatch.setenv("HF_HOME", "/my/cache")
+        monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+        with pytest.raises(RuntimeError, match=r"currently '/my/cache'"):
+            raise_model_load_error("some/model", "/cache", False, OSError("err"))
+
+    def test_hf_home_shown_as_unset(self, monkeypatch):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+        monkeypatch.delenv("HF_HOME", raising=False)
+        monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+        with pytest.raises(RuntimeError, match="currently unset"):
+            raise_model_load_error("some/model", "/cache", False, OSError("err"))
+
+    def test_allow_fetch_off_node_reraises_cause(self, monkeypatch):
+        monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+        with pytest.raises(OSError, match="network error"):
+            raise_model_load_error(
+                "some/model", "/cache", True, OSError("network error")
+            )
 
 
 class TestGetTokenizer:


### PR DESCRIPTION
Updates `raise_model_load_error()` to include hints to set `HF_HUB_OFFLINE=1` if not set and `HF_HOME` if needed (these need to be set in the case where there is no internet access and `--no-allow-fetch` and/or `--cache-dir` are not being passed to internal calls). Also refactors the `embed` task to use `raise_model_load_error()` helper. 

Additionally, updates the `embed` docs to mention this might be a needed fix and adds tests for `raise_model_load_error()`.

Closes #233 