### PR TITLE
ci: drop invalid python-version-file input from setup-uv

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,6 @@ jobs:
           cache-dependency-glob: |
             uv.lock
             pyproject.toml
-          python-version-file: ".python-version"
 
       # The version is bumped in-repo via PR before tagging (the release tag is
       # cut from the bumped commit), so CD only verifies they agree — it never
@@ -75,7 +74,6 @@ jobs:
           cache-dependency-glob: |
             uv.lock
             pyproject.toml
-          python-version-file: ".python-version"
 
       - name: Install dependencies
         run: uv sync --locked --group docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
-          python-version-file: ".python-version"
 
       - name: Check lockfile is up to date
         run: uv lock --check
@@ -52,7 +51,6 @@ jobs:
           cache-dependency-glob: |
             uv.lock
             pyproject.toml
-          python-version-file: ".python-version"
 
       - name: Install dependencies
         run: uv sync --locked --group lint --no-extra vllm
@@ -103,7 +101,6 @@ jobs:
           cache-dependency-glob: |
             uv.lock
             pyproject.toml
-          python-version-file: ".python-version"
 
       - name: Build the package
         run: uv build
@@ -136,7 +133,6 @@ jobs:
           cache-dependency-glob: |
             uv.lock
             pyproject.toml
-          python-version-file: ".python-version"
 
       - name: Install dependencies
         run: uv sync --locked --group docs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
-          python-version-file: ".python-version"
           cache-local-path: ${{ env.UV_CACHE_DIR }}
 
       - name: Install dependencies


### PR DESCRIPTION
Closes #150.

`astral-sh/setup-uv` has no `python-version-file` input (confirmed against `action.yml` on the `v7` tag — only `python-version` and `version-file` exist). It was silently ignored, producing the `Unexpected input(s) 'python-version-file'` annotation on integration/CD runs.

Removed the input at all 7 sites rather than converting to `python-version: "3.10"`: since the input was already ignored, removal is provably behavior-preserving, whereas setting `python-version` would newly export `UV_PYTHON` and change resolution. `uv` continues to read `.python-version` (3.10) from the repo root on its own.

- `ci.yml` — lock, lint, build, docs jobs (the `test` matrix keeps its valid `python-version: ${{ matrix.python-version }}`)
- `cd.yml` — publish, docs jobs
- `integration.yml` — integration job

The issue listed only `integration.yml` and `cd.yml`; `ci.yml` had four more occurrences.

The issue's second item (Node 20 deprecation) is already resolved on `main` — Dependabot bumps landed `actions/checkout@v7` and `astral-sh/setup-uv@v7`. No change needed here.